### PR TITLE
Add license id and copyright notice to each source file

### DIFF
--- a/examples/net6.0/aspnetcore/Controllers/HttpClientController.cs
+++ b/examples/net6.0/aspnetcore/Controllers/HttpClientController.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using Microsoft.AspNetCore.Mvc;
 
 namespace aspnetcore.Controllers;

--- a/examples/net6.0/aspnetcore/Controllers/MsSqlController.cs
+++ b/examples/net6.0/aspnetcore/Controllers/MsSqlController.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using System.Data;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Data.SqlClient;

--- a/examples/net6.0/aspnetcore/Controllers/RedisController.cs
+++ b/examples/net6.0/aspnetcore/Controllers/RedisController.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using StackExchange.Redis;

--- a/examples/net6.0/aspnetcore/Controllers/WeatherForecastController.cs
+++ b/examples/net6.0/aspnetcore/Controllers/WeatherForecastController.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using Microsoft.AspNetCore.Mvc;
 
 namespace aspnetcore.Controllers;

--- a/examples/net6.0/aspnetcore/Program.cs
+++ b/examples/net6.0/aspnetcore/Program.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using Grafana.OpenTelemetry;
 using Microsoft.Data.SqlClient;
 using StackExchange.Redis;

--- a/src/Grafana.OpenTelemetry.Base/ExporterSettings/AgentOtlpExporter.cs
+++ b/src/Grafana.OpenTelemetry.Base/ExporterSettings/AgentOtlpExporter.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using System;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Logs;

--- a/src/Grafana.OpenTelemetry.Base/ExporterSettings/CloudOtlpExporter.cs
+++ b/src/Grafana.OpenTelemetry.Base/ExporterSettings/CloudOtlpExporter.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using System;
 using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Exporter;

--- a/src/Grafana.OpenTelemetry.Base/ExporterSettings/ExporterSettings.cs
+++ b/src/Grafana.OpenTelemetry.Base/ExporterSettings/ExporterSettings.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;

--- a/src/Grafana.OpenTelemetry.Base/ExporterSettings/GrafanaCloudConfigurationHelper.cs
+++ b/src/Grafana.OpenTelemetry.Base/ExporterSettings/GrafanaCloudConfigurationHelper.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using System;
 
 namespace Grafana.OpenTelemetry

--- a/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryEventSource.cs
+++ b/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryEventSource.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using System;
 using System.Diagnostics.Tracing;
 using System.Text.Json;

--- a/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryResourceDetector.cs
+++ b/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryResourceDetector.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using System.Collections.Generic;
 using System.Reflection;
 using OpenTelemetry.Resources;

--- a/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetrySettings.cs
+++ b/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetrySettings.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/AWSInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/AWSInitializer.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using OpenTelemetry.Trace;
 
 namespace Grafana.OpenTelemetry

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/AWSLambdaInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/AWSLambdaInitializer.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using OpenTelemetry.Trace;
 
 namespace Grafana.OpenTelemetry

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/AspNetCoreInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/AspNetCoreInitializer.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/AspNetInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/AspNetInitializer.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/CassandraInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/CassandraInitializer.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using OpenTelemetry.Metrics;
 
 namespace Grafana.OpenTelemetry

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/ElasticsearchClientInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/ElasticsearchClientInitializer.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using OpenTelemetry.Trace;
 
 namespace Grafana.OpenTelemetry

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/EntityFrameworkCoreInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/EntityFrameworkCoreInitializer.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using OpenTelemetry.Trace;
 
 namespace Grafana.OpenTelemetry

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/GrpcNetClientInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/GrpcNetClientInitializer.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using OpenTelemetry.Trace;
 
 namespace Grafana.OpenTelemetry

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/HangfireInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/HangfireInitializer.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using OpenTelemetry.Trace;
 
 namespace Grafana.OpenTelemetry

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/HttpClientInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/HttpClientInitializer.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/Instrumentation.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/Instrumentation.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 namespace Grafana.OpenTelemetry
 {
     /// <summary>

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/InstrumentationInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/InstrumentationInitializer.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using System;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/MySqlDataInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/MySqlDataInitializer.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using OpenTelemetry.Trace;
 
 namespace Grafana.OpenTelemetry

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/NetRuntimeMetricsInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/NetRuntimeMetricsInitializer.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using OpenTelemetry.Metrics;
 
 namespace Grafana.OpenTelemetry

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/OwinInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/OwinInitializer.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using OpenTelemetry.Trace;
 
 namespace Grafana.OpenTelemetry

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/ProcessMetricsInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/ProcessMetricsInitializer.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using OpenTelemetry.Metrics;
 
 namespace Grafana.OpenTelemetry

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/QuartzInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/QuartzInitializer.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using OpenTelemetry.Trace;
 
 namespace Grafana.OpenTelemetry

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/SqlClientInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/SqlClientInitializer.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using OpenTelemetry.Trace;
 
 namespace Grafana.OpenTelemetry

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/StackExchangeRedisInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/StackExchangeRedisInitializer.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using OpenTelemetry.Trace;
 
 namespace Grafana.OpenTelemetry

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/WcfInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/WcfInitializer.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using OpenTelemetry.Trace;
 
 namespace Grafana.OpenTelemetry

--- a/src/Grafana.OpenTelemetry.Base/MeterProviderBuilderExtensions.cs
+++ b/src/Grafana.OpenTelemetry.Base/MeterProviderBuilderExtensions.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using System;
 using System.Collections.Generic;
 using OpenTelemetry.Metrics;

--- a/src/Grafana.OpenTelemetry.Base/ReflectionHelper.cs
+++ b/src/Grafana.OpenTelemetry.Base/ReflectionHelper.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using System;
 using System.Linq;
 using System.Reflection;

--- a/src/Grafana.OpenTelemetry.Base/ResourceBuilderExtension.cs
+++ b/src/Grafana.OpenTelemetry.Base/ResourceBuilderExtension.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using OpenTelemetry.Resources;
 
 namespace Grafana.OpenTelemetry

--- a/src/Grafana.OpenTelemetry.Base/TracerProviderBuilderExtensions.cs
+++ b/src/Grafana.OpenTelemetry.Base/TracerProviderBuilderExtensions.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using System;
 using System.Collections.Generic;
 using OpenTelemetry.Trace;

--- a/tests/Grafana.OpenTelemetry.Tests/CloudOtlpExporterTest.cs
+++ b/tests/Grafana.OpenTelemetry.Tests/CloudOtlpExporterTest.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using System;
 using Xunit;
 

--- a/tests/Grafana.OpenTelemetry.Tests/GrafanaCloudConfigurationHelperTest.cs
+++ b/tests/Grafana.OpenTelemetry.Tests/GrafanaCloudConfigurationHelperTest.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using System;
 using Grafana.OpenTelemetry;
 using Xunit;

--- a/tests/Grafana.OpenTelemetry.Tests/GrafanaOpenTelemetrySettingsTest.cs
+++ b/tests/Grafana.OpenTelemetry.Tests/GrafanaOpenTelemetrySettingsTest.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using System;
 using System.Collections.Generic;
 using System.Reflection;

--- a/tests/Grafana.OpenTelemetry.Tests/InMemoryResourceExporter.cs
+++ b/tests/Grafana.OpenTelemetry.Tests/InMemoryResourceExporter.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using System;
 using System.Collections.Generic;
 using OpenTelemetry;

--- a/tests/Grafana.OpenTelemetry.Tests/MeterProviderExtensionsTest.cs
+++ b/tests/Grafana.OpenTelemetry.Tests/MeterProviderExtensionsTest.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using Grafana.OpenTelemetry;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;

--- a/tests/Grafana.OpenTelemetry.Tests/ReflectionHelperTest.cs
+++ b/tests/Grafana.OpenTelemetry.Tests/ReflectionHelperTest.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using System;
 using Grafana.OpenTelemetry;
 using Xunit;

--- a/tests/Grafana.OpenTelemetry.Tests/TracerProviderExtensionsTest.cs
+++ b/tests/Grafana.OpenTelemetry.Tests/TracerProviderExtensionsTest.cs
@@ -1,3 +1,8 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;


### PR DESCRIPTION
Fixes grafana/app-o11y#414

## Changes

Consistent with the Java distro, this PR adds the following license id and copyright notice to each source file:

```
//
// Copyright Grafana Labs
// SPDX-License-Identifier: Apache-2.0
//
```

## Merge requirement checklist

* [ ] Unit tests added/updated
* [ ] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
