### PR TITLE
Add `UseGrafana` extension method for ASP.NET Core projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ specifies what instrumentations are included in the base package.
 * [Configuring metrics](#configuring-metrics)
 * [Configuring logs](#configuring-logs)
 * [Configuring traces](#configuring-traces)
+* [ASP.NET Core](#aspnet-core)
 * [Exporter configuration](#exporter-configuration)
   * [Sending to an agent or collector via OTLP](#sending-to-an-agent-or-collector-via-otlp)
   * [Sending data directly to Grafana Cloud via OTLP](#sending-data-directly-to-grafana-cloud-via-otlp)
@@ -139,6 +140,21 @@ extension method on the `TracerProviderBuilder`.
 using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .UseGrafana()
     .Build();
+```
+
+### ASP.NET Core
+
+For ASP.NET Core applications, a `UseGrafana` extension method is provided on
+the `IServiceCollection`. Invoking this extension method configures both traces
+and metrics.
+
+Logging can be set up using the `ILoggingBuilder`, as described in [Configuring logs](#configuring-logs).
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddOpenTelemetry().UseGrafana();
+builder.Logging.AddOpenTelemetry(logging => logging.UseGrafana());
 ```
 
 ### Exporter configuration

--- a/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
+++ b/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
@@ -27,6 +27,11 @@
     </PackageReference>
   </ItemGroup>
 
+  <!-- Stable instrumentation packages with dependencies, only .NET -->
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net462' ">
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" /> <!-- needed for AspNetCore -->
+  </ItemGroup>
+
   <!-- Non-stable instrumentation packages with dependencies, both .NET framework and .NET -->
   <ItemGroup>
     <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.1.0-beta.1" />

--- a/src/Grafana.OpenTelemetry/OpenTelemetryBuilderExtension.cs
+++ b/src/Grafana.OpenTelemetry/OpenTelemetryBuilderExtension.cs
@@ -1,0 +1,35 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#if !NETFRAMEWORK
+
+using System;
+using OpenTelemetry;
+
+namespace Grafana.OpenTelemetry
+{
+    /// <summary>
+    /// Extension for the <see cref="OpenTelemetry.OpenTelemetryBuilder"/> provided by the OpenTelemetry .NET distribution 
+    /// for Grafana.
+    ///
+    /// This is used for easier configuration for ASP.NET Core projects.
+    /// </summary>
+    public static class OpenTelemetryBuilderExtension
+    {
+        /// <summary>
+        /// Sets up tracing and metrics with the OpenTelemetry .NET distribution for Grafana.
+        /// </summary>
+        /// <param name="builder">A <see cref="OpenTelemetryBuilder"/></param>
+        /// <param name="configure">A callback for customizing default Grafana OpenTelemetry settings</param>
+        /// <returns>A modified <see cref="OpenTelemetryBuilder"/> </returns>
+        public static OpenTelemetryBuilder UseGrafana(this OpenTelemetryBuilder builder, Action<GrafanaOpenTelemetrySettings> configure = default)
+        {
+            return builder
+                .WithTracing(tracerProviderBuilder => tracerProviderBuilder.UseGrafana(configure))
+                .WithMetrics(metricProviderBuilder => metricProviderBuilder.UseGrafana(configure));
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Fixes grafana/app-o11y#431

## Changes

Adds a `UseGrafana` extension method on the `OpenTelemetryBuilder` which is used for setting up ASP.NET Core projects.

## Merge requirement checklist

* [ ] Unit tests added/updated
* [ ] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
