### PR TITLE
Default to using stable HTTP semantic conventions

### DIFF
--- a/src/Grafana.OpenTelemetry.Base/MeterProviderBuilderExtensions.cs
+++ b/src/Grafana.OpenTelemetry.Base/MeterProviderBuilderExtensions.cs
@@ -31,11 +31,11 @@ namespace Grafana.OpenTelemetry
 
             GrafanaOpenTelemetryEventSource.Log.InitializeDistribution(settings);
 
-	    // Default to using stable HTTP semantic conventions
+            // Default to using stable HTTP semantic conventions
             if (Environment.GetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN") == null)
-	    {
+            {
                 Environment.SetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN", "http");
-	    }
+            }
 
             return builder
                 .AddGrafanaExporter(settings?.ExporterSettings)

--- a/src/Grafana.OpenTelemetry.Base/OpenTelemetryLoggerOptionsExtensions.cs
+++ b/src/Grafana.OpenTelemetry.Base/OpenTelemetryLoggerOptionsExtensions.cs
@@ -32,11 +32,11 @@ namespace Grafana.OpenTelemetry
 
             GrafanaOpenTelemetryEventSource.Log.InitializeDistribution(settings);
 
-	    // Default to using stable HTTP semantic conventions
+            // Default to using stable HTTP semantic conventions
             if (Environment.GetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN") == null)
-	    {
+            {
                 Environment.SetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN", "http");
-	    }
+            }
 
             var resourceBuilder = ResourceBuilder
                 .CreateDefault()

--- a/src/Grafana.OpenTelemetry.Base/TracerProviderBuilderExtensions.cs
+++ b/src/Grafana.OpenTelemetry.Base/TracerProviderBuilderExtensions.cs
@@ -31,11 +31,11 @@ namespace Grafana.OpenTelemetry
 
             GrafanaOpenTelemetryEventSource.Log.InitializeDistribution(settings);
 
-	    // Default to using stable HTTP semantic conventions
+            // Default to using stable HTTP semantic conventions
             if (Environment.GetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN") == null)
-	    {
+            {
                 Environment.SetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN", "http");
-	    }
+            }
 
             return builder
                 .AddGrafanaExporter(settings?.ExporterSettings)


### PR DESCRIPTION
Fixes grafana/app-o11y#507

## Changes

This makes it the default for distro users to use stable HTTP semantic conventions (for components that support the environment variable).

Enforcing this as a default now will avoid future breaking changes as components will switch to emitting stable HTTP semantic conventions by default.

## Merge requirement checklist

* [ ] Unit tests added/updated
* [ ] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
