### PR TITLE
Change Getting Started to send to Grafana Cloud via OTLP

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,22 +33,35 @@ dotnet add package --prerelease Grafana.OpenTelemetry
 The `UseGrafana` extension method on the `TracerProviderBuilder` or the
 `MetricProviderBuilder` can be used to set up the Grafana distribution. By
 default, telemetry data will be sent to a Grafana agent or an OTel collector
-that runs locally and listens to default OTLP ports:
+that runs locally and listens to default OTLP ports.
+
+Given the zone, instance id, and API token, telemetry data can be sent directly
+to the Grafana Cloud without involving an agent or collector:
 
 ```csharp
-using OpenTelemetry;
-using OpenTelemetry.Trace;
-using Grafana.OpenTelemetry;
-
-public class Program
-{
-    public static void Main(string[] args)
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .UseGrafana(config =>
     {
-        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .UseGrafana()
-            .Build();
-    }
-}
+        config.ExporterSettings = new CloudOtlpExporter
+        {
+            Zone = "prod-us-east-0",
+            InstanceId = "123456",
+            ApiKey = "a-secret-token"
+        };
+    })
+    .Build();
+```
+
+For details on how to obtain those values, refer to [Send data using OpenTelemetry Protocol](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/otlp/send-data-otlp/).
+
+Alternatively, these values can be set via the environment variables
+`GRAFANA_CLOUD_ZONE`, `GRAFANA_CLOUD_INSTANCE_ID`, and
+`GRAFANA_CLOUD_API_KEY`.
+
+```sh
+export GRAFANA_CLOUD_ZONE=prod-us-east-0
+export GRAFANA_CLOUD_INSTANCE_ID=123456
+export GRAFANA_CLOUD_API_KEY=a-secret-token
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .Build();
 ```
 
-For details on how to obtain those values, refer to [Send data using OpenTelemetry Protocol](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/otlp/send-data-otlp/).
+For details on how to obtain those values, refer to [Send data using
+OpenTelemetry
+Protocol](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/otlp/send-data-otlp/).
 
 Alternatively, these values can be set via the environment variables
 `GRAFANA_CLOUD_ZONE`, `GRAFANA_CLOUD_INSTANCE_ID`, and

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
 This is a pre-configured and pre-packaged bundle of [OpenTelemetry .NET components](http://github.com/open-telemetry/opentelemetry-dotnet-contrib),
 optimized for [Grafana Cloud Application Observability](https://grafana.com/docs/grafana-cloud/monitor-applications/application-observability/).
 
+It requires only minimal setup and configuration and makes it very easy to emit
+OpenTelemetry traces, logs, and metrics from your .NET application.
+
 ## Getting Started
 
 ### Step 1: Install package


### PR DESCRIPTION
## Changes

This brings our README in line with the blog post and the getting started guides in App O11y.

This makes it easier for customers to get started without doing any agent or collector setup.

## Merge requirement checklist

* [ ] Unit tests added/updated
* [ ] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
