### PR TITLE
Update ASP.NET instrumentation type name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fixes exception when activating ASP.NET metrics instrumentation
+
 ## 0.1.6.0-beta
 
 Released 2023-11-08

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/AspNetInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/AspNetInitializer.cs
@@ -25,7 +25,7 @@ namespace Grafana.OpenTelemetry
         {
             ReflectionHelper.CallStaticMethod(
                 "OpenTelemetry.Instrumentation.AspNet",
-                "OpenTelemetry.Trace.TracerProviderBuilderExtensions",
+                "OpenTelemetry.Metrics.MeterProviderBuilderExtensions",
                 "AddAspNetInstrumentation",
                 new object[] { builder });
         }


### PR DESCRIPTION
## Changes

Updates ASP.NET instrumentation type name. Previously was looking in the Trace namespace when activating metrics.

## Merge requirement checklist

* [ ] ~Unit tests added/updated~
* [x] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
