### PR TITLE
Updates reflection lookup / OWIN tracing instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Fixes exception when activating ASP.NET metrics instrumentation
+* Fixes exception when activating OWIN tracing instrumentation
 
 ## 0.1.6.0-beta
 

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/OwinInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/OwinInitializer.cs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+using System;
 using OpenTelemetry.Trace;
 
 namespace Grafana.OpenTelemetry
@@ -17,7 +18,7 @@ namespace Grafana.OpenTelemetry
                 "OpenTelemetry.Instrumentation.Owin",
                 "OpenTelemetry.Trace.TracerProviderBuilderExtensions",
                 "AddOwinInstrumentation",
-                new object[] { builder });
+                new object[] { builder, null });
         }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/ReflectionHelper.cs
+++ b/src/Grafana.OpenTelemetry.Base/ReflectionHelper.cs
@@ -15,7 +15,7 @@ namespace Grafana.OpenTelemetry
         {
             var assembly = Assembly.Load(assemblyName);
             var type = assembly.GetType(typeName);
-            var method = type.GetMethod(methodName, arguments.Select(obj => obj.GetType()).ToArray());
+            var method = type.GetMethod(methodName, arguments.Select(obj => obj is null ? null : obj.GetType()).ToArray());
             method.Invoke(null, arguments);
         }
     }


### PR DESCRIPTION
## Changes

Updates OWIN tracing instrumentation reflection lookup strategy. The method overload definition in the OWIN instrumentation causes one method to be exposed with the signature:

```csharp
public static TracerProviderBuilder AddOwinInstrumentation(
        this TracerProviderBuilder builder,
        Action<OwinInstrumentationOptions> configure = null)
```
[Original file](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/src/OpenTelemetry.Instrumentation.Owin/TracerProviderBuilderExtensions.cs
)

The other instrumentations typically expose two methods:

1. One argument (TracerProviderBuilder )
2. Two arguments (TracerProviderBuilder, configuration action)

The `=>` syntax used upstream to define the method overload causes the compiler to only generate the second method signature, with the configuration action being null by default.

This PR updates the method lookup code to allow passing desired arguments and nulls, matching the optional argument used in the OWIN instrumentation.

## Merge requirement checklist

* [ ] ~Unit tests added/updated~
* [x] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
