### PR TITLE
Improve values for distro name and version attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Populate `telemetry.distro.version` with the readable file version.
+
 ## 0.6.0-beta.1
 
 Released 2023-11-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Populate `telemetry.distro.version` with the readable file version.
+* Improve accuracy of resource attributes `telemetry.distro.name` and `telemetry.distro.version`.
 
 ## 0.6.0-beta.1
 

--- a/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryResourceDetector.cs
+++ b/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryResourceDetector.cs
@@ -16,7 +16,7 @@ namespace Grafana.OpenTelemetry
         internal const string ResourceKey_DistroName = "telemetry.distro.name";
         internal const string ResourceKey_DistroVersion = "telemetry.distro.version";
         internal const string ResourceKey_DeploymentEnvironment = "deployment.environment";
-	internal const string ResourceValue_DistroName = "grafana-opentelemetry-dotnet";
+        internal const string ResourceValue_DistroName = "grafana-opentelemetry-dotnet";
 
         private GrafanaOpenTelemetrySettings _settings;
 

--- a/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryResourceDetector.cs
+++ b/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryResourceDetector.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Reflection;
 using OpenTelemetry.Resources;
 
@@ -15,6 +16,7 @@ namespace Grafana.OpenTelemetry
         internal const string ResourceKey_DistroName = "telemetry.distro.name";
         internal const string ResourceKey_DistroVersion = "telemetry.distro.version";
         internal const string ResourceKey_DeploymentEnvironment = "deployment.environment";
+	internal const string ResourceValue_DistroName = "grafana-opentelemetry-dotnet";
 
         private GrafanaOpenTelemetrySettings _settings;
 
@@ -29,8 +31,8 @@ namespace Grafana.OpenTelemetry
 
             return new Resource(new KeyValuePair<string, object>[]
             {
-                new KeyValuePair<string, object>(ResourceKey_DistroName, assembly.GetName().Name),
-                new KeyValuePair<string, object>(ResourceKey_DistroVersion, assembly.GetName().Version.ToString()),
+                new KeyValuePair<string, object>(ResourceKey_DistroName, ResourceValue_DistroName),
+                new KeyValuePair<string, object>(ResourceKey_DistroVersion, FileVersionInfo.GetVersionInfo(assembly.Location).ProductVersion),
                 new KeyValuePair<string, object>(ResourceKey_DeploymentEnvironment, _settings.DeploymentEnvironment)
             });
         }

--- a/tests/Grafana.OpenTelemetry.Tests/TracerProviderExtensionsTest.cs
+++ b/tests/Grafana.OpenTelemetry.Tests/TracerProviderExtensionsTest.cs
@@ -52,7 +52,7 @@ namespace Grafana.OpenTelemetry.Tests
                 resourceTags.Add(tag.Key, (string)tag.Value);
             }
 
-            Assert.Equal("Grafana.OpenTelemetry.Base", resourceTags["telemetry.distro.name"]);
+            Assert.Equal("grafana-opentelemetry-dotnet", resourceTags["telemetry.distro.name"]);
             Assert.NotNull(resourceTags["telemetry.distro.version"]);
 
             Assert.NotNull(resourceTags["service.name"]);


### PR DESCRIPTION
## Changes

* `telemetry.distro.name` is hardcoded to "grafana-opentelemetry-dotnet", which I think is more in line with conventions around `telemetry` attributes and is easier readable then `Grafana.OpenTelemetry.Base`.
* `telemetry.distro.version` is set to the file version (e. g. "0.6.0-beta.1"), which is different from the assembly version ("0.0.0.0").

## Merge requirement checklist

* [ ] Unit tests added/updated
* [ ] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
