### PR TITLE
Include the Visual Studio test runner for all build targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Unreleased
 
+### New features
+
 * Improve accuracy of resource attributes `telemetry.distro.name` and `telemetry.distro.version`.
+
+### Bug fixes
+
+* Make unit tests runnable for non-net462 targets.
 
 ## 0.6.0-beta.1
 

--- a/tests/Grafana.OpenTelemetry.Tests/Grafana.OpenTelemetry.Tests.csproj
+++ b/tests/Grafana.OpenTelemetry.Tests/Grafana.OpenTelemetry.Tests.csproj
@@ -15,12 +15,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <PackageReference Include="xunit.runner.visualstudio" Version="[2.5.0,3.0)">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
+      <NoWarn>NU1701</NoWarn>
     </PackageReference>
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #49 

## Changes

Including `xunit.runner.visualstudio` (despite warnings on non-.NET Framework platforms), as this makes the test runner work on all platforms.

## Merge requirement checklist

* [x] Unit tests added/updated
* [x] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
