### PR TITLE
Add documentation of how to minimize package dependencies

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@
   * [Sending data directly to Grafana Cloud via OTLP](#sending-data-directly-to-grafana-cloud-via-otlp)
 * [Instrumentation configuration](#instrumentation-configuration)
   * [Disabling instrumentations](#disabling-instrumentations)
-  * [Adding instrumentations](#adding-instrumentations)
+  * [Adding instrumentations not supported by the distribution](#adding-instrumentations-not supported-by-the-distribution)
   * [Extra steps to activate specific instrumentations](#extra-steps-to-activate-specific-instrumentations)
     * [ASP.NET (`AspNet`)](#aspnet-aspnet)
     * [OWIN (`Owin`)](#owin-owin)
@@ -172,33 +172,36 @@ from the table above:
 export GRAFANA_DOTNET_DISABLE_INSTRUMENTATIONS="Process,NetRuntime"
 ```
 
-### Adding instrumentations
+### Adding instrumentations not supported by the distribution
 
 Instrumentations not included in the distribution can easily be added by
 extension methods on the tracer and meter provider.
 
-For example, it is desired to use the `AspNetCore` instrumentation in
-combination with the [base package](./installation.md#install-the-base-package)
-(which doesn't include the `AspNetCore` package), you can install the
-`AspNetCore` instrumentation library along with the base package.
+For example, if it is desired to use the `EventCounters` instrumentation, which is
+not included in the [full package](./installation.md#install-the-full-package),
+one install the `EventCounters` instrumentation library along with the base
+package.
 
 ```sh
 dotnet add package --prerelease Grafana.OpenTelemetry.Base
-dotnet add package --prerelease OpenTelemetry.Instrumentation.AspNetCore
+dotnet add package OpenTelemetry.Instrumentation.EventCounters --prerelease
 ```
 
-Then, the `AspNetCore` instrumentation can be enabled via the [`AddAspNetCoreInstrumentation`](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Instrumentation.AspNetCore#step-2-enable-aspnet-core-instrumentation-at-application-startup)
+Then, the `EventCounters` instrumentation can be enabled via the [`AddEventCountersInstrumentation`](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.EventCounters#step-2-enable-eventcounters-instrumentation)
 extension method, alongside the `UseGrafana` method.
 
 ```csharp
 using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .UseGrafana()
-    .AddAspNetCoreInstrumentation()
+    .AddEventCountersInstrumentation(options => {
+        options.RefreshIntervalSecs = 1;
+        options.AddEventSources("MyEventSource");
+    })
     .Build();
 ```
 
-This way, any other instrumentation library can be added according the
-documentation provided with it.
+This way, any other instrumentation library [not supported by the distribution](./supported-instrumentations.md)
+can be added according to the documentation provided with it.
 
 ### Extra steps to activate specific instrumentations
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@
   * [Sending data directly to Grafana Cloud via OTLP](#sending-data-directly-to-grafana-cloud-via-otlp)
 * [Instrumentation configuration](#instrumentation-configuration)
   * [Disabling instrumentations](#disabling-instrumentations)
-  * [Adding instrumentations not supported by the distribution](#adding-instrumentations-not supported-by-the-distribution)
+  * [Adding instrumentations not supported by the distribution](#adding-instrumentations-not-supported-by-the-distribution)
   * [Extra steps to activate specific instrumentations](#extra-steps-to-activate-specific-instrumentations)
     * [ASP.NET (`AspNet`)](#aspnet-aspnet)
     * [OWIN (`Owin`)](#owin-owin)
@@ -178,7 +178,7 @@ Instrumentations not included in the distribution can easily be added by
 extension methods on the tracer and meter provider.
 
 For example, if it is desired to use the `EventCounters` instrumentation, which is
-not included in the [full package](./installation.md#install-the-full-package),
+not included in the [full package](./installation.md#install-the-full-package-with-all-available-instrumentations),
 one install the `EventCounters` instrumentation library along with the base
 package.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,10 @@
 # Installing the Grafana OpenTelemetry distribution for .NET
 
+* [Supported .NET Versions](#supported-net-versions)
+* [Install the full package with all available instrumentations](#install-the-full-package-with-all-available-instrumentations)
+* [Install the base package](#install-the-base-package)
+* [Minimizing unneeded dependencies](#minimizing-unneeded-dependencies)
+
 ## Supported .NET Versions
 
 The packages shipped from this repository generally support all the officially
@@ -36,3 +41,40 @@ dotnet add package --prerelease Grafana.OpenTelemetry.Base
 
 The list of [supported instrumentations](./supported-instrumentations.md)
 specifies what instrumentations are included in the base package.
+
+## Minimizing unneeded dependencies
+
+Users might utilize some instrumentation libraries the [full package](#install-the-full-package)
+contains, while other contained libraries will not be needed. However, the
+[full package](#install-the-full-package) still pulls in those
+unneeded instrumentations libraries with their dependencies.
+
+To mitigate this situation, [base package](#install-the-base-package)
+with a built-in lazy-loading mechanism can be used. This mechanism will
+initialize any known available instrumentation library assembly, regardless of
+whether it's added as dependency of the [full package](#install-the-full-package)
+or as part of the instrumented project.
+
+For example, if it is desired to use the `AspNetCore` instrumentation without
+pulling in any other dependencies from the [full package](#install-the-full-package),
+it suffices to install the `AspNetCore` instrumentation library along with the
+base package.
+
+```sh
+dotnet add package --prerelease Grafana.OpenTelemetry.Base
+dotnet add package --prerelease OpenTelemetry.Instrumentation.AspNetCore
+```
+
+Then, the `AspNetCore` instrumentation will be lazy-loaded during the
+invocation of the `UseGrafana` extension method, no further code changes are
+necessary.
+
+```csharp
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .UseGrafana()
+    .Build();
+```
+
+This way, any other instrumentation library [supported by the distribution](./supported-instrumentations.md)
+can be added via lazy loading.
+

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,8 +46,9 @@ specifies what instrumentations are included in the base package.
 
 Users might utilize some instrumentation libraries the [full package](#install-the-full-package-with-all-available-instrumentations)
 contains, while other contained libraries will not be needed. However, the
-[full package](#install-the-full-package-with-all-available-instrumentations) still pulls in those
-unneeded instrumentations libraries with their dependencies.
+[full package](#install-the-full-package-with-all-available-instrumentations)
+still pulls in those unneeded instrumentations libraries with their
+dependencies.
 
 To mitigate this situation, [base package](#install-the-base-package)
 with a built-in lazy-loading mechanism can be used. This mechanism will
@@ -77,4 +78,3 @@ using var tracerProvider = Sdk.CreateTracerProviderBuilder()
 
 This way, any other instrumentation library [supported by the distribution](./supported-instrumentations.md)
 can be added via lazy loading.
-

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -44,19 +44,19 @@ specifies what instrumentations are included in the base package.
 
 ## Minimizing unneeded dependencies
 
-Users might utilize some instrumentation libraries the [full package](#install-the-full-package)
+Users might utilize some instrumentation libraries the [full package](#install-the-full-package-with-all-available-instrumentations)
 contains, while other contained libraries will not be needed. However, the
-[full package](#install-the-full-package) still pulls in those
+[full package](#install-the-full-package-with-all-available-instrumentations) still pulls in those
 unneeded instrumentations libraries with their dependencies.
 
 To mitigate this situation, [base package](#install-the-base-package)
 with a built-in lazy-loading mechanism can be used. This mechanism will
 initialize any known available instrumentation library assembly, regardless of
-whether it's added as dependency of the [full package](#install-the-full-package)
+whether it's added as dependency of the [full package](#install-the-full-package-with-all-available-instrumentations)
 or as part of the instrumented project.
 
 For example, if it is desired to use the `AspNetCore` instrumentation without
-pulling in any other dependencies from the [full package](#install-the-full-package),
+pulling in any other dependencies from the [full package](#install-the-full-package-with-all-available-instrumentations),
 it suffices to install the `AspNetCore` instrumentation library along with the
 base package.
 


### PR DESCRIPTION
Fixes grafana/app-o11y#506

## Changes

* Replace the existing "Adding instrumentations" (using AspNet as an example) with "Adding instrumentations not supported by the distribution" (using EventCounters as example), to make it clear customers can use instrumentation libraries not contained in the distro.
* Add a section "Minimizing unneeded dependencies" to the installation documentation, highlighting how lazy-loading can be utilized to minimize dependencies by manually picking needed instrumentation libraries.

## Merge requirement checklist

* [ ] Unit tests added/updated
* [ ] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
