### PR TITLE
Allow specifying custom resource attributes via `GrafanaOpenTelemetrySettings`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-* Allow specifying custom resource attributes on `GrafanaOpenTelemetrySettings`.
+* Allow specifying custom resource attributes via `GrafanaOpenTelemetrySettings`.
 * Improve accuracy of resource attributes `telemetry.distro.name` and `telemetry.distro.version`.
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* Allow specifying custom resource attributes on `GrafanaOpenTelemetrySettings`.
 * Improve accuracy of resource attributes `telemetry.distro.name` and `telemetry.distro.version`.
 
 ### Bug fixes

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -254,7 +254,7 @@ for further details.
 
 ### Customizing resource attributes
 
-The `GrafanaOpenTelemetrySettings` has dedicated fields for setting standard
+The type `GrafanaOpenTelemetrySettings` has dedicated fields for setting standard
 OpenTelemetry resource attributes for service name, service version, instance
 id, and deployment environment. Those fields are populated with reasonable
 default values, but can be customized.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -282,6 +282,14 @@ using var tracerProvider = Sdk.CreateMeterProviderBuilder()
     .Build();
 ```
 
+Alternatively, those attributes can be set via standard OpenTelemetry
+environment variables.
+
+```sh
+export OTEL_SERVICE_NAME="service-name"
+export OTEL_RESOURCE_ATTRIBUTES="service.version=1.0,service.instance.id=instance=34531,deployment.environment=production,custom.key=custom-value"
+```
+
 ## Custom configuration
 
 The distribution is designed to be easily extensible with components that it

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -252,6 +252,36 @@ Refer to the [upstream
 documentation](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.Owin#step-2-configure-owin-middleware)
 for further details.
 
+### Customizing resource attributes
+
+The `GrafanaOpenTelemetrySettings` has dedicated fields for setting standard
+OpenTelemetry resource attributes for service name, service version, instance
+id, and deployment environment. Those fields are populated with reasonable
+default values, but can be customized.
+
+```csharp
+using var tracerProvider = Sdk.CreateMeterProviderBuilder()
+    .UseGrafana(config =>
+    {
+        config.ServiceName = "service-name";
+        config.ServiceVersion= "1.0";
+        config.ServiceInstanceId = "instance-34532";
+        config.DeploymentEnvironment = "production";
+    })
+    .Build();
+```
+
+Custom resource attributes can be set via the `ResourceAttributes` dictionary:
+
+```csharp
+using var tracerProvider = Sdk.CreateMeterProviderBuilder()
+    .UseGrafana(config =>
+    {
+        config.ResourceAttributes["custom.key"] = "custom-value";
+    })
+    .Build();
+```
+
 ## Custom configuration
 
 The distribution is designed to be easily extensible with components that it

--- a/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryResourceDetector.cs
+++ b/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryResourceDetector.cs
@@ -36,7 +36,7 @@ namespace Grafana.OpenTelemetry
                 new KeyValuePair<string, object>(ResourceKey_DeploymentEnvironment, _settings.DeploymentEnvironment)
             });
 
-	    attributes.AddRange(_settings.ResourceAttributes);
+            attributes.AddRange(_settings.ResourceAttributes);
 
             return new Resource(attributes);
         }

--- a/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryResourceDetector.cs
+++ b/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryResourceDetector.cs
@@ -29,12 +29,16 @@ namespace Grafana.OpenTelemetry
         {
             var assembly = typeof(GrafanaOpenTelemetryResourceDetector).Assembly;
 
-            return new Resource(new KeyValuePair<string, object>[]
+            var attributes = new List<KeyValuePair<string, object>>(new KeyValuePair<string, object>[]
             {
                 new KeyValuePair<string, object>(ResourceKey_DistroName, ResourceValue_DistroName),
                 new KeyValuePair<string, object>(ResourceKey_DistroVersion, FileVersionInfo.GetVersionInfo(assembly.Location).ProductVersion),
                 new KeyValuePair<string, object>(ResourceKey_DeploymentEnvironment, _settings.DeploymentEnvironment)
             });
+
+	    attributes.AddRange(_settings.ResourceAttributes);
+
+            return new Resource(attributes);
         }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetrySettings.cs
+++ b/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetrySettings.cs
@@ -74,6 +74,11 @@ namespace Grafana.OpenTelemetry
         public string DeploymentEnvironment { get; set; } = "production";
 
         /// <summary>
+        /// Gets a dictionary of custom resource attributes.
+        /// </summary>
+        public IDictionary<string, object> ResourceAttributes { get; } = new Dictionary<string, object>();
+
+        /// <summary>
         /// Initializes an instance of <see cref="GrafanaOpenTelemetrySettings"/>.
         /// </summary>
         public GrafanaOpenTelemetrySettings()

--- a/tests/Grafana.OpenTelemetry.Tests/TracerProviderExtensionsTest.cs
+++ b/tests/Grafana.OpenTelemetry.Tests/TracerProviderExtensionsTest.cs
@@ -43,11 +43,11 @@ namespace Grafana.OpenTelemetry.Tests
             span.Stop();
             span.Dispose();
 
-            Assert.Single(spans);
+            var activity = Assert.Single(spans);
 
             var resourceTags = new Dictionary<string, string>();
 
-            foreach (var tag in spans[0].Item2.Attributes)
+            foreach (var tag in activity.Item2.Attributes)
             {
                 resourceTags.Add(tag.Key, (string)tag.Value);
             }
@@ -81,11 +81,11 @@ namespace Grafana.OpenTelemetry.Tests
             span.Stop();
             span.Dispose();
 
-            Assert.Single(spans);
+            var activity = Assert.Single(spans);
 
             var resourceTags = new Dictionary<string, string>();
 
-            foreach (var tag in spans[0].Item2.Attributes)
+            foreach (var tag in activity.Item2.Attributes)
             {
                 resourceTags.Add(tag.Key, (string)tag.Value);
             }
@@ -118,11 +118,11 @@ namespace Grafana.OpenTelemetry.Tests
             span.Stop();
             span.Dispose();
 
-            Assert.Single(spans);
+            var activity = Assert.Single(spans);
 
             var resourceTags = new Dictionary<string, string>();
 
-            foreach (var tag in spans[0].Item2.Attributes)
+            foreach (var tag in activity.Item2.Attributes)
             {
                 resourceTags.Add(tag.Key, (string)tag.Value);
             }
@@ -150,11 +150,11 @@ namespace Grafana.OpenTelemetry.Tests
             span.Stop();
             span.Dispose();
 
-            Assert.Single(spans);
+            var activity = Assert.Single(spans);
 
             var resourceTags = new Dictionary<string, string>();
 
-            foreach (var tag in spans[0].Item2.Attributes)
+            foreach (var tag in activity.Item2.Attributes)
             {
                 resourceTags.Add(tag.Key, (string)tag.Value);
             }

--- a/tests/Grafana.OpenTelemetry.Tests/TracerProviderExtensionsTest.cs
+++ b/tests/Grafana.OpenTelemetry.Tests/TracerProviderExtensionsTest.cs
@@ -70,9 +70,9 @@ namespace Grafana.OpenTelemetry.Tests
                 .CreateTracerProviderBuilder()
                 .UseGrafana(settings =>
                 {
-		    settings.ServiceName = "service-name";
-		    settings.ResourceAttributes["custom.attribute"] = "custom_value";
-		})
+                    settings.ServiceName = "service-name";
+                    settings.ResourceAttributes["custom.attribute"] = "custom_value";
+                })
                 .AddProcessor(new SimpleActivityExportProcessor(new InMemoryResourceExporter<Activity>(spans)))
                 .AddSource(activitySource.Name)
                 .Build();


### PR DESCRIPTION
Fixes #57

## Changes

This adds a dictionary `GrafanaOpenTelemetrySettings.ResourceAttributes`, which allows specifying custom resource attributes which will be applied the `ResourceBuilder` set on provider builders.

This ensures a consistent resource configuration for traces, logs, and metrics.

## Merge requirement checklist

* [x] Unit tests added/updated
* [x] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
