### PR TITLE
Obtain distro version from the informational assembly version

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -5,3 +5,7 @@ default: true
 MD013:
   code_blocks: false
   tables: false
+
+# Allow same headers for non-siblings, e. g. in the CHANGELOG
+MD024:
+  siblings_only: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Bug fixes
+
+* [#65](https://github.com/grafana/grafana-opentelemetry-dotnet/issues/65):
+  Using the distribution broke self-contained applications. This has been fixed
+  by using a different way to determine the distribution version.
+* [#64](https://github.com/grafana/grafana-opentelemetry-dotnet/issues/64): The
+  version in `telemetry.distro.version` contained a trailing commit hash. This
+  commit hash is removed now before populating the attribute.
+
 ## 0.6.0-beta.2
 
 ### New features

--- a/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryResourceDetector.cs
+++ b/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryResourceDetector.cs
@@ -48,7 +48,7 @@ namespace Grafana.OpenTelemetry
 
             if (string.IsNullOrWhiteSpace(informationalVersion))
             {
-                    informationalVersion = "0.0.0";
+                informationalVersion = "0.0.0";
             }
 
             // A Git hash is appended to the informational version after a "+" character. That's of limited use and

--- a/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryResourceDetector.cs
+++ b/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryResourceDetector.cs
@@ -27,12 +27,10 @@ namespace Grafana.OpenTelemetry
 
         public Resource Detect()
         {
-            var assembly = typeof(GrafanaOpenTelemetryResourceDetector).Assembly;
-
             var attributes = new List<KeyValuePair<string, object>>(new KeyValuePair<string, object>[]
             {
                 new KeyValuePair<string, object>(ResourceKey_DistroName, ResourceValue_DistroName),
-                new KeyValuePair<string, object>(ResourceKey_DistroVersion, FileVersionInfo.GetVersionInfo(assembly.Location).ProductVersion),
+                new KeyValuePair<string, object>(ResourceKey_DistroVersion, GetDistroVersion()),
                 new KeyValuePair<string, object>(ResourceKey_DeploymentEnvironment, _settings.DeploymentEnvironment)
             });
 
@@ -40,5 +38,21 @@ namespace Grafana.OpenTelemetry
 
             return new Resource(attributes);
         }
+
+	static internal string GetDistroVersion()
+	{
+            var assembly = typeof(GrafanaOpenTelemetryResourceDetector).Assembly;
+
+            var assemblyInformationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+
+	    if (string.IsNullOrWhiteSpace(assemblyInformationalVersion)) 
+	    {
+                assemblyInformationalVersion = "0.0.0";
+	    }
+
+	    // A Git hash is appended to the informational version after a "+" character. That's of limited use and
+	    // therefore removed here.
+	    return assemblyInformationalVersion.Split("+")[0];
+	}
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryResourceDetector.cs
+++ b/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryResourceDetector.cs
@@ -39,20 +39,21 @@ namespace Grafana.OpenTelemetry
             return new Resource(attributes);
         }
 
-	static internal string GetDistroVersion()
-	{
-            var assembly = typeof(GrafanaOpenTelemetryResourceDetector).Assembly;
+        static internal string GetDistroVersion()
+        {
+            var informationalVersion = typeof(GrafanaOpenTelemetryResourceDetector)
+                .Assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                .InformationalVersion;
 
-            var assemblyInformationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
-
-	    if (string.IsNullOrWhiteSpace(assemblyInformationalVersion)) 
-	    {
-                assemblyInformationalVersion = "0.0.0";
-	    }
-
-	    // A Git hash is appended to the informational version after a "+" character. That's of limited use and
-	    // therefore removed here.
-	    return assemblyInformationalVersion.Split("+")[0];
-	}
+            if (string.IsNullOrWhiteSpace(informationalVersion)) 
+            {
+                    informationalVersion = "0.0.0";
+            }
+    
+            // A Git hash is appended to the informational version after a "+" character. That's of limited use and
+            // therefore removed here.
+            return informationalVersion.Split("+")[0];
+        }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryResourceDetector.cs
+++ b/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryResourceDetector.cs
@@ -46,14 +46,14 @@ namespace Grafana.OpenTelemetry
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
                 .InformationalVersion;
 
-            if (string.IsNullOrWhiteSpace(informationalVersion)) 
+            if (string.IsNullOrWhiteSpace(informationalVersion))
             {
                     informationalVersion = "0.0.0";
             }
-    
+
             // A Git hash is appended to the informational version after a "+" character. That's of limited use and
             // therefore removed here.
-            return informationalVersion.Split("+")[0];
+            return informationalVersion.Split('+')[0];
         }
     }
 }


### PR DESCRIPTION
Fixes #65
Fixes #64 

## Changes

This follows the same approach taken in the upstream OpenTelemetry SDK for obtaining the SDK version. The distribution version is taken from the [informational assembly version](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.assemblyinformationalversionattribute?view=net-8.0), which can be obtained for self-contained projects too.

The existing approach for obtaining the assembly version fails for self-contained projects, as it's based on determining the assembly file.

## Merge requirement checklist

* ~~[ ] Unit tests added/updated~~
* [x] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
