### PR TITLE
Adapt to upstream extension class name changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+* [#71](https://github.com/grafana/grafana-opentelemetry-dotnet/issues/71):
+  Lazy-loading of ASP.NET Core instrumentation was broken. This was fixed by
+  updateing changed class names of ASP.NET Core instrumentation library
+  extension classes.
+
 ## 0.7.0-beta.1
 
 ### BREAKING CHANGES

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/AspNetCoreInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/AspNetCoreInitializer.cs
@@ -16,7 +16,7 @@ namespace Grafana.OpenTelemetry
         {
             ReflectionHelper.CallStaticMethod(
                 "OpenTelemetry.Instrumentation.AspNetCore",
-                "OpenTelemetry.Trace.TracerProviderBuilderExtensions",
+                "OpenTelemetry.Trace.AspNetCoreInstrumentationTracerProviderBuilderExtensions",
                 "AddAspNetCoreInstrumentation",
                 new object[] { builder });
         }
@@ -25,7 +25,7 @@ namespace Grafana.OpenTelemetry
         {
             ReflectionHelper.CallStaticMethod(
                 "OpenTelemetry.Instrumentation.AspNetCore",
-                "OpenTelemetry.Metrics.MeterProviderBuilderExtensions",
+                "OpenTelemetry.Metrics.AspNetCoreInstrumentationMeterProviderBuilderExtensions",
                 "AddAspNetCoreInstrumentation",
                 new object[] { builder });
         }


### PR DESCRIPTION
Fixes #71

## Changes

With the 1.7.0 upstream ASP.NET Core instrumentation libraries, extension classes were renamed (open-telemetry/opentelemetry-dotnet#5161). This also requires updating class names used for lazy-loading in our distro. This PR updates the distro to use the new class names:
* `AspNetCoreInstrumentationTracerProviderBuilderExtensions`
* `AspNetCoreInstrumentationMeterProviderBuilderExtensions`

## Merge requirement checklist

* [ ] Unit tests added/updated
* [x] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
