### PR TITLE
Enable experimental gRPC instrumentation when enabling tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Sets `OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_ENABLE_GRPC_INSTRUMENTATION`
+  to `true` when enabling tracing. [gRPC instrumentation is experimental](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/Instrumentation.AspNetCore-1.6.0),
+  while HTTP is stable.
+
 ### Bug fixes
 
 * [#71](https://github.com/grafana/grafana-opentelemetry-dotnet/issues/71):

--- a/src/Grafana.OpenTelemetry.Base/MeterProviderBuilderExtensions.cs
+++ b/src/Grafana.OpenTelemetry.Base/MeterProviderBuilderExtensions.cs
@@ -31,10 +31,10 @@ namespace Grafana.OpenTelemetry
 
             GrafanaOpenTelemetryEventSource.Log.InitializeDistribution(settings);
 
-            // Default to using stable HTTP semantic conventions
-            if (Environment.GetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN") == null)
+            // Default to using experimental gRPC instrumentation
+            if (Environment.GetEnvironmentVariable("OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_ENABLE_GRPC_INSTRUMENTATION") == null)
             {
-                Environment.SetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN", "http");
+                Environment.SetEnvironmentVariable("OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_ENABLE_GRPC_INSTRUMENTATION", "true");
             }
 
             return builder


### PR DESCRIPTION
Fixes #74 

## Changes

Sets `OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_ENABLE_GRPC_INSTRUMENTATION` to `true` when enabling tracing, similar to what was done for metrics in 0.7.0-beta.1

## Merge requirement checklist

* [ ] ~Unit tests added/updated~
* [x] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
