### PR TITLE
Fix missing heading for release 0.7.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   to `true` when enabling tracing. [gRPC instrumentation is experimental](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/Instrumentation.AspNetCore-1.6.0),
   while HTTP is stable.
 
+## 0.7.0-beta.2
+
 ### Bug fixes
 
 * [#71](https://github.com/grafana/grafana-opentelemetry-dotnet/issues/71):


### PR DESCRIPTION
## Changes

Restores heading in CHANGELOG for 0.7.0-beta.2

## Merge requirement checklist

* [ ] Unit tests added/updated
* [x] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
