### PR TITLE
Adds "data saver" mode that only exports Grafana Application Observability metrics

### DIFF
--- a/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetrySettings.cs
+++ b/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetrySettings.cs
@@ -18,6 +18,7 @@ namespace Grafana.OpenTelemetry
     {
         internal const string DisableInstrumentationsEnvVarName = "GRAFANA_DOTNET_DISABLE_INSTRUMENTATIONS";
         internal const string ServiceNameEnvVarName = "OTEL_SERVICE_NAME";
+        internal const string DataSaverEnvVarName = "GRAFANA_OTEL_APPLICATION_OBSERVABILITY_METRICS";
 
         // As a workaround, a static random service instance id is initialized and used as default.
         // This is to avoid different instance ids to be created by provider builders for different
@@ -79,6 +80,13 @@ namespace Grafana.OpenTelemetry
         public IDictionary<string, object> ResourceAttributes { get; } = new Dictionary<string, object>();
 
         /// <summary>
+        /// Gets or sets whether "data saver" mode is enabled.
+        ///
+        /// When enabled, the distribution will only export metrics required for Grafana Application Observability.
+        /// </summary>
+        public bool DataSaverEnabled { get; set; } = false;
+
+        /// <summary>
         /// Initializes an instance of <see cref="GrafanaOpenTelemetrySettings"/>.
         /// </summary>
         public GrafanaOpenTelemetrySettings()
@@ -132,6 +140,13 @@ namespace Grafana.OpenTelemetry
                 {
                     DeploymentEnvironment = deploymentEnvironment.ToLower();
                 }
+            }
+
+            var dataSaver = configuration[DataSaverEnvVarName];
+
+            if (bool.TryParse(dataSaver, out var dataSaverEnabled))
+            {
+                DataSaverEnabled = dataSaverEnabled;
             }
         }
     }

--- a/src/Grafana.OpenTelemetry.Base/MeterProviderBuilderExtensions.cs
+++ b/src/Grafana.OpenTelemetry.Base/MeterProviderBuilderExtensions.cs
@@ -41,7 +41,7 @@ namespace Grafana.OpenTelemetry
                 .AddGrafanaExporter(settings?.ExporterSettings)
                 .AddInstrumentations(settings?.Instrumentations)
                 .ConfigureResource(resourceBuilder => resourceBuilder.AddGrafanaResource(settings))
-                .DropUnusedMetrics();
+                .DropUnusedMetrics(settings);
         }
 
         internal static MeterProviderBuilder AddGrafanaExporter(this MeterProviderBuilder builder, ExporterSettings settings)
@@ -69,8 +69,13 @@ namespace Grafana.OpenTelemetry
             return builder;
         }
 
-        internal static MeterProviderBuilder DropUnusedMetrics(this MeterProviderBuilder builder)
+        internal static MeterProviderBuilder DropUnusedMetrics(this MeterProviderBuilder builder, GrafanaOpenTelemetrySettings settings)
         {
+            if (settings.DataSaverEnabled)
+            {
+                return builder;
+            }
+
             var allow = new MetricStreamConfiguration();
 
             return builder.AddView("application", allow)

--- a/src/Grafana.OpenTelemetry.Base/MeterProviderBuilderExtensions.cs
+++ b/src/Grafana.OpenTelemetry.Base/MeterProviderBuilderExtensions.cs
@@ -83,7 +83,7 @@ namespace Grafana.OpenTelemetry
                 .AddView("memory.usage", allow)
                 .AddView("process.threads", allow)
                 .AddView("process.runtime.dotnet.gc.objects.size", allow)
-                .AddView("*", MetricStreamConfiguration.Drop));
+                .AddView("*", MetricStreamConfiguration.Drop);
         }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/MeterProviderBuilderExtensions.cs
+++ b/src/Grafana.OpenTelemetry.Base/MeterProviderBuilderExtensions.cs
@@ -40,7 +40,8 @@ namespace Grafana.OpenTelemetry
             return builder
                 .AddGrafanaExporter(settings?.ExporterSettings)
                 .AddInstrumentations(settings?.Instrumentations)
-                .ConfigureResource(resourceBuilder => resourceBuilder.AddGrafanaResource(settings));
+                .ConfigureResource(resourceBuilder => resourceBuilder.AddGrafanaResource(settings))
+                .DropUnusedMetrics();
         }
 
         internal static MeterProviderBuilder AddGrafanaExporter(this MeterProviderBuilder builder, ExporterSettings settings)
@@ -66,6 +67,18 @@ namespace Grafana.OpenTelemetry
             }
 
             return builder;
+        }
+
+        internal static MeterProviderBuilder DropUnusedMetrics(this MeterProviderBuilder builder)
+        {
+            var allow = new MetricStreamConfiguration();
+
+            return builder.AddView("application", allow)
+                .AddView("process.cpu.time", allow)
+                .AddView("memory.usage", allow)
+                .AddView("process.threads", allow)
+                .AddView("process.runtime.dotnet.gc.objects.size", allow)
+                .AddView("*", MetricStreamConfiguration.Drop));
         }
     }
 }


### PR DESCRIPTION
Fixes #

## Changes

Adds "data saver" mode that only exports Grafana Application Observability metrics.

To enable, set the environment variable `GRAFANA_OTEL_APPLICATION_OBSERVABILITY_METRICS` to `true`.

Only the following metrics will be emitted:

- `process.cpu.time`
- `memory.usage`
- `process.threads`
- `process.runtime.dotnet.gc.objects.size`

User defined metrics may be exported by naming the Meter "application".

## Merge requirement checklist

* [ ] Unit tests added/updated
* [ ] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
