### PR TITLE
OATs build fixes, better HTTP error test

### DIFF
--- a/docker/docker-compose-aspnetcore/http/oats.http-get.yaml
+++ b/docker/docker-compose-aspnetcore/http/oats.http-get.yaml
@@ -1,9 +1,10 @@
 docker-compose:
   generator: lgtm
   files:
-    - ./docker-compose.oats.yml
+    - ../docker-compose.oats.yml
 input:
   - path: /api/HttpClient/Get
+interval: 500ms
 expected:
   traces:
     - traceql: '{ name =~ "api/HttpClient/Get" }'
@@ -12,5 +13,5 @@ expected:
           attributes:
             http.request.method: GET
   metrics:
-    - promql: http_client_request_duration_count{}
+    - promql: http_client_request_duration_count{http_request_method="GET", http_response_status_code="200"}
       value: '>= 0'

--- a/docker/docker-compose-aspnetcore/http/oats.http-geterror.yaml
+++ b/docker/docker-compose-aspnetcore/http/oats.http-geterror.yaml
@@ -1,19 +1,18 @@
 docker-compose:
   generator: lgtm
   files:
-    - ./docker-compose.oats.yml
+    - ../docker-compose.oats.yml
 input:
   - path: /api/HttpClient/GetError
+interval: 500ms
 expected:
   traces:
     - traceql: '{ name =~ "api/HttpClient/GetError" }'
       spans:
         - name: 'GET'
           attributes:
-            error: true
-            error.type: 500
+            error.type: '500'
             http.request.method: GET
-            http.response.status_code: 500
   metrics:
     - promql: http_client_request_duration_count{}
       value: '>= 0'

--- a/docker/docker-compose-aspnetcore/oats.http-get.yaml
+++ b/docker/docker-compose-aspnetcore/oats.http-get.yaml
@@ -8,9 +8,9 @@ expected:
   traces:
     - traceql: '{ name =~ "api/HttpClient/Get" }'
       spans:
-        - name: 'HTTP GET'
+        - name: 'GET'
           attributes:
-            http.method: GET
+            http.request.method: GET
   metrics:
     - promql: http_client_request_duration_count{}
       value: '>= 0'

--- a/docker/docker-compose-aspnetcore/oats.http-get.yaml
+++ b/docker/docker-compose-aspnetcore/oats.http-get.yaml
@@ -12,5 +12,5 @@ expected:
           attributes:
             http.method: GET
   metrics:
-    - promql: http_client_duration_count{}
+    - promql: http_client_request_duration_count{}
       value: '>= 0'

--- a/docker/docker-compose-aspnetcore/oats.http-geterror.yaml
+++ b/docker/docker-compose-aspnetcore/oats.http-geterror.yaml
@@ -1,0 +1,19 @@
+docker-compose:
+  generator: lgtm
+  files:
+    - ./docker-compose.oats.yml
+input:
+  - path: /api/HttpClient/GetError
+expected:
+  traces:
+    - traceql: '{ name =~ "api/HttpClient/GetError" }'
+      spans:
+        - name: 'HTTP GET'
+          attributes:
+            error: true
+            error.type: 500
+            http.method: GET
+            http.response.status_code: 500
+  metrics:
+    - promql: http_client_request_duration_count{}
+      value: '>= 0'

--- a/docker/docker-compose-aspnetcore/oats.http-geterror.yaml
+++ b/docker/docker-compose-aspnetcore/oats.http-geterror.yaml
@@ -8,11 +8,11 @@ expected:
   traces:
     - traceql: '{ name =~ "api/HttpClient/GetError" }'
       spans:
-        - name: 'HTTP GET'
+        - name: 'GET'
           attributes:
             error: true
             error.type: 500
-            http.method: GET
+            http.request.method: GET
             http.response.status_code: 500
   metrics:
     - promql: http_client_request_duration_count{}

--- a/examples/net6.0/aspnetcore/Controllers/HttpClientController.cs
+++ b/examples/net6.0/aspnetcore/Controllers/HttpClientController.cs
@@ -30,7 +30,7 @@ public class HttpClientController : ControllerBase
     public async Task<ActionResult<IEnumerable<string>>> GetError()
     {
         var client = new HttpClient();
-        var response = await client.GetAsync("http://example.com");
+        var response = await client.GetAsync("http://postman-echo.com/status/500");
         var content = await response.Content.ReadAsStringAsync();
         return Ok(content);
     }

--- a/examples/net6.0/aspnetcore/Dockerfile
+++ b/examples/net6.0/aspnetcore/Dockerfile
@@ -4,7 +4,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["examples/net6.0/aspnetcore/aspnetcore.csproj", "examples/net6.0/aspnetcore/"]
 RUN dotnet restore "examples/net6.0/aspnetcore/aspnetcore.csproj"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "8.0.100-rc.2.23502.2"
+    "version": "8.0.101"
   }
 }


### PR DESCRIPTION
## Changes

Updates build for .NET 8 SDK
Improves HTTP GET error controller action to return a 500, and adds OATs test looking for HTTP error span.

## Merge requirement checklist

* [x] Unit tests added/updated
* [ ] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
