### PR TITLE
Add OATS tests to GH actions

### DIFF
--- a/.github/workflows/oats.yml
+++ b/.github/workflows/oats.yml
@@ -1,4 +1,4 @@
-name: Acceptance Tests
+name: OATS Tests
 
 on:
   pull_request:
@@ -17,7 +17,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: grafana/oats
-          ref: 557ba8902303e3e83580d79fc1d2c07afe14d715
           path: oats
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/oats.yml
+++ b/.github/workflows/oats.yml
@@ -1,0 +1,34 @@
+name: Acceptance Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  acceptance-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+      - name: Check out oats
+        uses: actions/checkout@v4
+        with:
+          repository: grafana/oats
+          ref: 557ba8902303e3e83580d79fc1d2c07afe14d715
+          path: oats
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.20'
+          cache-dependency-path: oats/go.sum
+      - name: Run acceptance tests
+        run: ./scripts/run-oats-tests.sh
+      - name: upload log file
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: docker-compose.log
+          path: oats/yaml/build/**/output.log

--- a/scripts/run-oats-tests.sh
+++ b/scripts/run-oats-tests.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd oats/yaml
+go install github.com/onsi/ginkgo/v2/ginkgo
+export TESTCASE_SKIP_BUILD=true
+export TESTCASE_TIMEOUT=5m
+export TESTCASE_BASE_PATH=../../docker
+ginkgo -r


### PR DESCRIPTION
## Changes

This adds a GH action for running OATS tests.

## Merge requirement checklist

* [ ] ~~Unit tests added/updated~~
* [ ] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
