### PR TITLE
Add badge for OATS tests

### DIFF
--- a/.github/workflows/oats.yml
+++ b/.github/workflows/oats.yml
@@ -1,11 +1,10 @@
 name: OATS Tests
 
 on:
-  pull_request:
-    branches:
-      - main
-    types:
-      - closed
+  push:
+    branches: [ 'main*' ]
+    paths-ignore:
+    - '**.md'
 
 jobs:
   acceptance-tests:

--- a/.github/workflows/oats.yml
+++ b/.github/workflows/oats.yml
@@ -1,4 +1,4 @@
-name: OATS Tests
+name: OATS
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 <!-- markdown-link-check-disable -->
 [![Build](https://github.com/grafana/grafana-opentelemetry-dotnet/actions/workflows/unit-tests.yml/badge.svg?branch=main)](https://github.com/grafana/grafana-opentelemetry-dotnet/actions/workflows/unit-tests.yml)
+[![OATS](https://github.com/grafana/grafana-opentelemetry-dotnet/actions/workflows/oats.yml/badge.svg?branch=main)](https://github.com/grafana/grafana-opentelemetry-dotnet/actions/workflows/oats.yml)
 [![Nuget](https://img.shields.io/nuget/v/Grafana.OpenTelemetry.svg)](https://www.nuget.org/profiles/Grafana)
 [![SDK](https://img.shields.io/badge/otel--sdk-1.6.0-blue?style=flat&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-dotnet)
 [![Slack](https://img.shields.io/badge/join%20slack-%23app--o11y-brightgreen.svg?logo=slack)](https://grafana.slack.com/archives/C05E87XRK3J)


### PR DESCRIPTION
## Changes

Similar to the "Build" badge for unit tests, this adds an "OATS" badge showing whether OATS integration tests ran successfully for the `main` branch.

## Merge requirement checklist

* [ ] ~~Unit tests added/updated~~
* [ ] ~~[`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
