### PR TITLE
Add all resource detectors from the .NET contrib repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 * [#81](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/81)
   Adds a .NET 8 test project and integrates it into the OATS test matrix.
 * [#85](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/85)
-  Adds resource detectors for host, process, process runtime, and container
-  resource attributes.
+  Adds resource detectors for Azure, host, process, process runtime, and
+  container resource attributes.
 
 ## 0.7.0-beta.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 * [#81](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/81)
   Adds a .NET 8 test project and integrates it into the OATS test matrix.
+* [#85](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/85)
+  Adds resource detectors for host, process, process runtime, and container
+  resource attributes.
 
 ## 0.7.0-beta.3
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ To disable self-diagnostics, delete the above file.
 To engage with the Grafana Application Observability community:
 
 * Chat with us on our community Slack channel. To invite yourself to the
-  Grafana Slack, visit [https://slack.grafana.com/](https://slack.grafana.com)
+  Grafana Slack, visit [https://grafana.slack.com/](https://grafana.slack.com)
   and join the [#application-observability](https://grafana.slack.com/archives/C05E87XRK3J)
   channel.
 * Ask questions on the [Discussions page](https://github.com/grafana/grafana-opentelemetry-dotnet/discussions).

--- a/docker/docker-compose-aspnetcore/attributes/oats-template.yml
+++ b/docker/docker-compose-aspnetcore/attributes/oats-template.yml
@@ -1,0 +1,17 @@
+matrix:
+  - name: default
+    docker-compose:
+      generator: lgtm
+      files:
+        - ../docker-compose.oats.yml
+  - name: self-contained
+    docker-compose:
+      generator: lgtm
+      files:
+        - ../docker-compose.self-contained.oats.yml
+  - name: net8
+    docker-compose:
+      generator: lgtm
+      files:
+        - ../docker-compose.net8.oats.yml
+interval: 500ms

--- a/docker/docker-compose-aspnetcore/attributes/oats.default-resource-attributes.yaml
+++ b/docker/docker-compose-aspnetcore/attributes/oats.default-resource-attributes.yaml
@@ -1,0 +1,25 @@
+include:
+  - ./oats-template.yml
+input:
+  - path: /api/HttpClient/Get
+expected:
+  traces:
+    - traceql: '{ name =~ "api/HttpClient/Get" }'
+      spans:
+        - name: 'GET'
+          attributes:
+            service.name: aspnetcore
+            service.version: 1.0.0.0
+            telemetry.distro.name: grafana-opentelemetry-dotnet
+            telemetry.distro.version: regex:.+
+            deployment.environment: production
+            process.runtime.description: regex:.NET.+
+            process.runtime.name: .NET
+            process.runtime.version: regex:.+
+            host.name: regex:.+
+            telemetry.sdk.name: opentelemetry
+            telemetry.sdk.language: dotnet
+            telemetry.sdk.version: regex:.+
+    - traceql: '{ resource.process.pid > 0 }'
+      spans:
+        - name: 'GET'

--- a/docs/supported-instrumentations.md
+++ b/docs/supported-instrumentations.md
@@ -10,14 +10,20 @@ and [minimal](./installation.md#install-the-base-package) dependencies:
 | `AspNetCore`          | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.AspNetCore](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNetCore) |
 | `AWS`                 | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.AWS](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AWS) |
 | `AWSLambda`           | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.AWSLambda](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AWSLambda) |
+| `AWSResource`         | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.ResourceDetectors.AWS](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.ResourceDetectors.AWS) |
+| `AzureResource`       | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.ResourceDetectors.Azure](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.ResourceDetectors.Azure) |
 | `Cassandra`           | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.Cassandra](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Cassandra) |
+| `ContainerResource`   | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.ResourceDetectors.Container](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.ResourceDetectors.Container) |
 | `ElasticsearchClient` | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.ElasticsearchClient](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.ElasticsearchClient) |
 | `EntityFrameworkCore` | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.EntityFrameworkCore](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.EntityFrameworkCore) |
 | `GrpcNetClient`       | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Instrumentation.GrpcNetClient](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.GrpcNetClient) |
 | `Hangfire`            | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.Hangfire](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Hangfire) |
 | `HttpClient`          | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Instrumentation.Http](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Http) |
+| `HostResource`        | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.ResourceDetectors.Host](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.ResourceDetectors.Host) |
 | `NetRuntime`          | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Instrumentation.Runtime](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Runtime) |
 | `Process`             | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Instrumentation.Process](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Process) |
+| `ProcessResource`     | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.ResourceDetectors.Process](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.ResourceDetectors.Process) |
+| `ProcessRuntimeResource`| :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.ResourceDetectors.ProcessRuntime](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.ResourceDetectors.ProcessRuntime) |
 | `MySqlData`           | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Instrumentation.MySqlData](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.MySqlData) |
 |                       | :heavy_check_mark: |                    | [MySql.Data.OpenTelemetry](https://www.nuget.org/packages/MySql.Data.OpenTelemetry) |
 | `Owin`                | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.Owin](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Owin) |
@@ -26,5 +32,8 @@ and [minimal](./installation.md#install-the-base-package) dependencies:
 | `StackExchangeRedis`  | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.StackExchangeRedis](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.StackExchangeRedis) |
 | `Wcf`                 | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.Wcf](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Wcf) |
 
-The `AWSLambda` instrumentation is included but needs to be explicitly
-activated, as activating it in non-AWS scenarios causes errors.
+* The `AWSLambda` instrumentation is included but needs to be explicitly
+  activated, as activating it in non-AWS scenarios causes errors.
+* The `ContainerResource` instrumentation is included but needs to be explicitly
+  activated, as it currently adds container resource attributes for processes
+  running not in containers. 

--- a/docs/supported-instrumentations.md
+++ b/docs/supported-instrumentations.md
@@ -36,4 +36,4 @@ and [minimal](./installation.md#install-the-base-package) dependencies:
   activated, as activating it in non-AWS scenarios causes errors.
 * The `ContainerResource` instrumentation is included but needs to be explicitly
   activated, as it currently adds container resource attributes for processes
-  running not in containers. 
+  running not in containers.

--- a/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
+++ b/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
@@ -43,6 +43,16 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.6.0-beta.3" />
+
+    <PackageReference Include="OpenTelemetry.ResourceDetectors.Azure" Version="1.0.0-beta.4" />
+    <PackageReference Include="OpenTelemetry.ResourceDetectors.Container" Version="1.0.0-beta.5" />
+  </ItemGroup>
+
+  <!-- Non-stable instrumentation packages with no dependencies, non netstandard2.0 -->
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+    <PackageReference Include="OpenTelemetry.ResourceDetectors.Host" Version="0.1.0-alpha.2" />
+    <PackageReference Include="OpenTelemetry.ResourceDetectors.Process" Version="0.1.0-alpha.2" />
+    <PackageReference Include="OpenTelemetry.ResourceDetectors.ProcessRuntime" Version="0.1.0-alpha.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
+++ b/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
@@ -44,6 +44,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.6.0-beta.3" />
 
+    <PackageReference Include="OpenTelemetry.ResourceDetectors.AWS" Version="1.4.0-beta.1" />
     <PackageReference Include="OpenTelemetry.ResourceDetectors.Azure" Version="1.0.0-beta.4" />
     <PackageReference Include="OpenTelemetry.ResourceDetectors.Container" Version="1.0.0-beta.5" />
   </ItemGroup>

--- a/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetrySettings.cs
+++ b/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetrySettings.cs
@@ -103,6 +103,10 @@ namespace Grafana.OpenTelemetry
             // De-activate it until the related issue is resolved: https://github.com/grafana/app-o11y/issues/378
             Instrumentations.Remove(Instrumentation.AWSLambda);
 
+            // Activating the container resource detector by default always populates a `container.id` attribute,
+	    // even when running in a non-container Linux setting.
+            Instrumentations.Remove(Instrumentation.ContainerResource);
+
             var disableInstrumentations = configuration[DisableInstrumentationsEnvVarName];
 
             if (!string.IsNullOrEmpty(disableInstrumentations))

--- a/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetrySettings.cs
+++ b/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetrySettings.cs
@@ -104,7 +104,7 @@ namespace Grafana.OpenTelemetry
             Instrumentations.Remove(Instrumentation.AWSLambda);
 
             // Activating the container resource detector by default always populates a `container.id` attribute,
-	    // even when running in a non-container Linux setting.
+            // even when running in a non-container Linux setting.
             Instrumentations.Remove(Instrumentation.ContainerResource);
 
             var disableInstrumentations = configuration[DisableInstrumentationsEnvVarName];

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/AWSResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/AWSResource.cs
@@ -1,0 +1,26 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
+using OpenTelemetry.ResourceDetectors.AWS;
+using OpenTelemetry.Resources;
+
+namespace Grafana.OpenTelemetry
+{
+    internal class AWSResourceInitializer : InstrumentationInitializer
+    {
+        public override Instrumentation Id { get; } = Instrumentation.AWSResource;
+
+        protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
+        {
+            return builder
+#if !NETFRAMEWORK && !NETSTANDARD
+                .AddDetector(new AWSECSResourceDetector())
+                .AddDetector(new AWSEKSResourceDetector())
+#endif
+                .AddDetector(new AWSEC2ResourceDetector())
+                .AddDetector(new AWSEBSResourceDetector());
+        }
+    }
+}

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/AzureResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/AzureResource.cs
@@ -1,0 +1,20 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
+using OpenTelemetry.Resources;
+using OpenTelemetry.ResourceDetectors.Azure;
+
+namespace Grafana.OpenTelemetry
+{
+    internal class AzureResourceInitializer : InstrumentationInitializer
+    {
+        public override Instrumentation Id { get; } = Instrumentation.AzureResource;
+
+        protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
+        {
+	    return builder.AddDetector(new AppServiceResourceDetector()); 
+        }
+    }
+}

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/AzureResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/AzureResource.cs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-using OpenTelemetry.Resources;
 using OpenTelemetry.ResourceDetectors.Azure;
+using OpenTelemetry.Resources;
 
 namespace Grafana.OpenTelemetry
 {
@@ -14,7 +14,7 @@ namespace Grafana.OpenTelemetry
 
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
-	    return builder.AddDetector(new AppServiceResourceDetector()); 
+            return builder.AddDetector(new AppServiceResourceDetector()); 
         }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/AzureResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/AzureResource.cs
@@ -14,7 +14,7 @@ namespace Grafana.OpenTelemetry
 
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
-            return builder.AddDetector(new AppServiceResourceDetector()); 
+            return builder.AddDetector(new AppServiceResourceDetector());
         }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/ContainerResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/ContainerResource.cs
@@ -1,0 +1,20 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
+using OpenTelemetry.Resources;
+using OpenTelemetry.ResourceDetectors.Container;
+
+namespace Grafana.OpenTelemetry
+{
+    internal class ContainerResourceInitializer : InstrumentationInitializer
+    {
+        public override Instrumentation Id { get; } = Instrumentation.ContainerResource;
+
+        protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
+        {
+	    return builder.AddDetector(new ContainerResourceDetector()); 
+        }
+    }
+}

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/ContainerResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/ContainerResource.cs
@@ -14,7 +14,7 @@ namespace Grafana.OpenTelemetry
 
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
-            return builder.AddDetector(new ContainerResourceDetector()); 
+            return builder.AddDetector(new ContainerResourceDetector());
         }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/ContainerResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/ContainerResource.cs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-using OpenTelemetry.Resources;
 using OpenTelemetry.ResourceDetectors.Container;
+using OpenTelemetry.Resources;
 
 namespace Grafana.OpenTelemetry
 {
@@ -14,7 +14,7 @@ namespace Grafana.OpenTelemetry
 
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
-	    return builder.AddDetector(new ContainerResourceDetector()); 
+            return builder.AddDetector(new ContainerResourceDetector()); 
         }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/HostResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/HostResource.cs
@@ -5,8 +5,8 @@
 
 #if !NETSTANDARD
 
-using OpenTelemetry.Resources;
 using OpenTelemetry.ResourceDetectors.Host;
+using OpenTelemetry.Resources;
 
 namespace Grafana.OpenTelemetry
 {
@@ -16,7 +16,7 @@ namespace Grafana.OpenTelemetry
 
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
-	    return builder.AddDetector(new HostDetector()); 
+            return builder.AddDetector(new HostDetector()); 
         }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/HostResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/HostResource.cs
@@ -16,7 +16,7 @@ namespace Grafana.OpenTelemetry
 
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
-            return builder.AddDetector(new HostDetector()); 
+            return builder.AddDetector(new HostDetector());
         }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/HostResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/HostResource.cs
@@ -1,0 +1,24 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#if !NETSTANDARD
+
+using OpenTelemetry.Resources;
+using OpenTelemetry.ResourceDetectors.Host;
+
+namespace Grafana.OpenTelemetry
+{
+    internal class HostResourceInitializer : InstrumentationInitializer
+    {
+        public override Instrumentation Id { get; } = Instrumentation.HostResource;
+
+        protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
+        {
+	    return builder.AddDetector(new HostDetector()); 
+        }
+    }
+}
+
+#endif

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/Instrumentation.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/Instrumentation.cs
@@ -98,6 +98,31 @@ namespace Grafana.OpenTelemetry
         /// <summary>
         /// WCF traces (OpenTelemetry.Instrumentation.Wcf)
         /// </summary>
-        Wcf
+        Wcf,
+
+        /// <summary>
+        /// Azure Resource Detector (OpenTelemetry.ResourceDetectors.Azure)
+        /// </summary>
+        AzureResource,
+
+        /// <summary>
+        /// Container Resource Detector (OpenTelemetry.ResourceDetectors.Container)
+        /// </summary>
+        ContainerResource,
+
+        /// <summary>
+        /// Host Resource Detector (OpenTelemetry.ResourceDetectors.Host)
+        /// </summary>
+        HostResource,
+
+        /// <summary>
+        /// Process Resource Detector (OpenTelemetry.ResourceDetectors.Process)
+        /// </summary>
+        ProcessResource,
+
+        /// <summary>
+        /// Process Runtime Resource Detector (OpenTelemetry.ResourceDetectors.ProcessRuntime)
+        /// </summary>
+        ProcessRuntimeResource
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/Instrumentation.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/Instrumentation.cs
@@ -101,6 +101,11 @@ namespace Grafana.OpenTelemetry
         Wcf,
 
         /// <summary>
+        /// AWS Resource Detector (OpenTelemetry.ResourceDetectors.AWS)
+        /// </summary>
+        AWSResource,
+
+        /// <summary>
         /// Azure Resource Detector (OpenTelemetry.ResourceDetectors.Azure)
         /// </summary>
         AzureResource,

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/InstrumentationInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/InstrumentationInitializer.cs
@@ -35,6 +35,7 @@ namespace Grafana.OpenTelemetry
             new SqlClientInitializer(),
             new StackExchangeRedisInitializer(),
             new WcfInitializer(),
+            new AWSResourceInitializer(),
             new AzureResourceInitializer(),
             new ContainerResourceInitializer(),
 #if !NETSTANDARD

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/InstrumentationInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/InstrumentationInitializer.cs
@@ -35,12 +35,12 @@ namespace Grafana.OpenTelemetry
             new SqlClientInitializer(),
             new StackExchangeRedisInitializer(),
             new WcfInitializer(),
-	    new AzureResourceInitializer(),
-	    new ContainerResourceInitializer(),
+            new AzureResourceInitializer(),
+            new ContainerResourceInitializer(),
 #if !NETSTANDARD
-	    new HostResourceInitializer(),
-	    new ProcessResourceInitializer(),
-	    new ProcessRuntimeResourceInitializer()
+            new HostResourceInitializer(),
+            new ProcessResourceInitializer(),
+            new ProcessRuntimeResourceInitializer()
 #endif
         };
 
@@ -77,14 +77,14 @@ namespace Grafana.OpenTelemetry
         }
 
         protected void InitializeResource(TracerProviderBuilder builder)
-        { 
-	    builder.ConfigureResource(resourceBuilder => InitializeResourceDetector(resourceBuilder));
-	}
+        {
+            builder.ConfigureResource(resourceBuilder => InitializeResourceDetector(resourceBuilder));
+        }
 
         protected void InitializeResource(MeterProviderBuilder builder)
-        { 
-	    builder.ConfigureResource(resourceBuilder => InitializeResourceDetector(resourceBuilder));
-	}
+        {
+            builder.ConfigureResource(resourceBuilder => InitializeResourceDetector(resourceBuilder));
+        }
 
         protected virtual void InitializeTracing(TracerProviderBuilder builder)
         { }
@@ -93,8 +93,8 @@ namespace Grafana.OpenTelemetry
         { }
 
         protected virtual ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
-        { 
-	    return builder;
-	}
+        {
+            return builder;
+        }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/InstrumentationInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/InstrumentationInitializer.cs
@@ -6,6 +6,7 @@
 using System;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
 namespace Grafana.OpenTelemetry
@@ -33,7 +34,14 @@ namespace Grafana.OpenTelemetry
             new QuartzInitializer(),
             new SqlClientInitializer(),
             new StackExchangeRedisInitializer(),
-            new WcfInitializer()
+            new WcfInitializer(),
+	    new AzureResourceInitializer(),
+	    new ContainerResourceInitializer(),
+#if !NETSTANDARD
+	    new HostResourceInitializer(),
+	    new ProcessResourceInitializer(),
+	    new ProcessRuntimeResourceInitializer()
+#endif
         };
 
         abstract public Instrumentation Id { get; }
@@ -43,6 +51,7 @@ namespace Grafana.OpenTelemetry
             try
             {
                 InitializeTracing(builder);
+                InitializeResource(builder);
 
                 GrafanaOpenTelemetryEventSource.Log.EnabledTracingInstrumentation(Id.ToString());
             }
@@ -57,6 +66,7 @@ namespace Grafana.OpenTelemetry
             try
             {
                 InitializeMetrics(builder);
+                InitializeResource(builder);
 
                 GrafanaOpenTelemetryEventSource.Log.EnabledMetricsInstrumentation(Id.ToString());
             }
@@ -66,10 +76,25 @@ namespace Grafana.OpenTelemetry
             }
         }
 
+        protected void InitializeResource(TracerProviderBuilder builder)
+        { 
+	    builder.ConfigureResource(resourceBuilder => InitializeResourceDetector(resourceBuilder));
+	}
+
+        protected void InitializeResource(MeterProviderBuilder builder)
+        { 
+	    builder.ConfigureResource(resourceBuilder => InitializeResourceDetector(resourceBuilder));
+	}
+
         protected virtual void InitializeTracing(TracerProviderBuilder builder)
         { }
 
         protected virtual void InitializeMetrics(MeterProviderBuilder builder)
         { }
+
+        protected virtual ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
+        { 
+	    return builder;
+	}
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/ProcessResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/ProcessResource.cs
@@ -1,0 +1,24 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#if !NETSTANDARD
+
+using OpenTelemetry.Resources;
+using OpenTelemetry.ResourceDetectors.Process;
+
+namespace Grafana.OpenTelemetry
+{
+    internal class ProcessResourceInitializer : InstrumentationInitializer
+    {
+        public override Instrumentation Id { get; } = Instrumentation.ProcessResource;
+
+        protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
+        {
+	    return builder.AddDetector(new ProcessDetector()); 
+        }
+    }
+}
+
+#endif

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/ProcessResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/ProcessResource.cs
@@ -16,7 +16,7 @@ namespace Grafana.OpenTelemetry
 
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
-            return builder.AddDetector(new ProcessDetector()); 
+            return builder.AddDetector(new ProcessDetector());
         }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/ProcessResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/ProcessResource.cs
@@ -5,8 +5,8 @@
 
 #if !NETSTANDARD
 
-using OpenTelemetry.Resources;
 using OpenTelemetry.ResourceDetectors.Process;
+using OpenTelemetry.Resources;
 
 namespace Grafana.OpenTelemetry
 {
@@ -16,7 +16,7 @@ namespace Grafana.OpenTelemetry
 
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
-	    return builder.AddDetector(new ProcessDetector()); 
+            return builder.AddDetector(new ProcessDetector()); 
         }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/ProcessRuntimeResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/ProcessRuntimeResource.cs
@@ -16,7 +16,7 @@ namespace Grafana.OpenTelemetry
 
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
-            return builder.AddDetector(new ProcessRuntimeDetector()); 
+            return builder.AddDetector(new ProcessRuntimeDetector());
         }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/ProcessRuntimeResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/ProcessRuntimeResource.cs
@@ -1,0 +1,24 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#if !NETSTANDARD
+
+using OpenTelemetry.Resources;
+using OpenTelemetry.ResourceDetectors.ProcessRuntime;
+
+namespace Grafana.OpenTelemetry
+{
+    internal class ProcessRuntimeResourceInitializer : InstrumentationInitializer
+    {
+        public override Instrumentation Id { get; } = Instrumentation.ProcessRuntimeResource;
+
+        protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
+        {
+	    return builder.AddDetector(new ProcessRuntimeDetector()); 
+        }
+    }
+}
+
+#endif

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/ProcessRuntimeResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/ProcessRuntimeResource.cs
@@ -5,8 +5,8 @@
 
 #if !NETSTANDARD
 
-using OpenTelemetry.Resources;
 using OpenTelemetry.ResourceDetectors.ProcessRuntime;
+using OpenTelemetry.Resources;
 
 namespace Grafana.OpenTelemetry
 {
@@ -16,7 +16,7 @@ namespace Grafana.OpenTelemetry
 
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
-	    return builder.AddDetector(new ProcessRuntimeDetector()); 
+            return builder.AddDetector(new ProcessRuntimeDetector()); 
         }
     }
 }

--- a/tests/Grafana.OpenTelemetry.Tests/GrafanaOpenTelemetrySettingsTest.cs
+++ b/tests/Grafana.OpenTelemetry.Tests/GrafanaOpenTelemetrySettingsTest.cs
@@ -28,15 +28,17 @@ namespace Grafana.OpenTelemetry.Tests
         }
 
         [Fact]
-        public void DefaultInstrumentationsWithoutAWSLambda()
+        public void DefaultInstrumentationsWithout()
         {
             var settings = new GrafanaOpenTelemetrySettings();
 
             // De-activate AWSLambda instrumenation until this issue is resolved: https://github.com/grafana/app-o11y/issues/378
+            // De-activate the container resource detector until it correctly detects processes not running in containers
             //
             // Once it's resolved, this test can be removed and the `DefaultInstrumentation` test can be re-activated.
             var expectedSettings = new HashSet<Instrumentation>((Instrumentation[])Enum.GetValues(typeof(Instrumentation)));
             expectedSettings.Remove(Instrumentation.AWSLambda);
+            expectedSettings.Remove(Instrumentation.ContainerResource);
 
             Assert.Equal(expectedSettings, settings.Instrumentations);
         }

--- a/tests/Grafana.OpenTelemetry.Tests/TracerProviderExtensionsTest.cs
+++ b/tests/Grafana.OpenTelemetry.Tests/TracerProviderExtensionsTest.cs
@@ -49,7 +49,10 @@ namespace Grafana.OpenTelemetry.Tests
 
             foreach (var tag in activity.Item2.Attributes)
             {
-                resourceTags.Add(tag.Key, (string)tag.Value);
+                if (tag.Value is string val)
+                {
+                    resourceTags.Add(tag.Key, val);
+                }
             }
 
             Assert.Equal("grafana-opentelemetry-dotnet", resourceTags["telemetry.distro.name"]);
@@ -87,7 +90,10 @@ namespace Grafana.OpenTelemetry.Tests
 
             foreach (var tag in activity.Item2.Attributes)
             {
-                resourceTags.Add(tag.Key, (string)tag.Value);
+                if (tag.Value is string val)
+                {
+                    resourceTags.Add(tag.Key, val);
+                }
             }
 
             Assert.Equal("custom_value", resourceTags["custom.attribute"]);
@@ -124,7 +130,10 @@ namespace Grafana.OpenTelemetry.Tests
 
             foreach (var tag in activity.Item2.Attributes)
             {
-                resourceTags.Add(tag.Key, (string)tag.Value);
+                if (tag.Value is string val)
+                {
+                    resourceTags.Add(tag.Key, val);
+                }
             }
 
             Assert.Equal("a", resourceTags["service.name"]);
@@ -156,7 +165,10 @@ namespace Grafana.OpenTelemetry.Tests
 
             foreach (var tag in activity.Item2.Attributes)
             {
-                resourceTags.Add(tag.Key, (string)tag.Value);
+                if (tag.Value is string val)
+                {
+                    resourceTags.Add(tag.Key, val);
+                }
             }
 
             Assert.Equal("service-name", resourceTags["service.name"]);

--- a/tests/Grafana.OpenTelemetry.Tests/TracerProviderExtensionsTest.cs
+++ b/tests/Grafana.OpenTelemetry.Tests/TracerProviderExtensionsTest.cs
@@ -45,23 +45,33 @@ namespace Grafana.OpenTelemetry.Tests
 
             var activity = Assert.Single(spans);
 
-            var resourceTags = new Dictionary<string, string>();
+            var resourceTags = new Dictionary<string, object>();
 
             foreach (var tag in activity.Item2.Attributes)
             {
-                if (tag.Value is string val)
-                {
-                    resourceTags.Add(tag.Key, val);
-                }
+                resourceTags.Add(tag.Key, tag.Value);
             }
 
-            Assert.Equal("grafana-opentelemetry-dotnet", resourceTags["telemetry.distro.name"]);
+            Assert.Equal("grafana-opentelemetry-dotnet", (string)resourceTags["telemetry.distro.name"]);
             Assert.NotNull(resourceTags["telemetry.distro.version"]);
 
             Assert.NotNull(resourceTags["service.name"]);
             Assert.NotNull(resourceTags["service.instance.id"]);
             Assert.NotNull(resourceTags["service.version"]);
+
             Assert.NotNull(resourceTags["deployment.environment"]);
+
+            Assert.NotNull(resourceTags["process.runtime.name"]);
+            Assert.NotNull(resourceTags["process.runtime.description"]);
+            Assert.NotNull(resourceTags["process.runtime.version"]);
+
+            Assert.NotNull(resourceTags["process.pid"]);
+
+            Assert.NotNull(resourceTags["host.name"]);
+
+            Assert.NotNull(resourceTags["telemetry.sdk.name"]);
+            Assert.NotNull(resourceTags["telemetry.sdk.language"]);
+            Assert.NotNull(resourceTags["telemetry.sdk.version"]);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes grafana/app-o11y#651

## Changes

This adds resource detectors for Azure, containers, hosts, processes, and process runtime.

## Merge requirement checklist

* [x] Unit tests added/updated
* [x] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
