### PR TITLE
Upgrades ASP.NET Core an HTTP instrumentation to 1.7.1, Runtime to 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## Unreleased
 
+### Bug fixes
+
+* Use 1.7.1 of ASP.NET Core instrumentation.
+  * Fixed issue
+  [#4466](https://github.com/open-telemetry/opentelemetry-dotnet/issues/4466)
+  where the activity instance returned by `Activity.Current` was different than
+  instance obtained from `IHttpActivityFeature.Activity`.
+  ([#5136](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5136))
+
+  * Fixed an issue where the `http.route` attribute was not set on either the
+  `Activity` or `http.server.request.duration` metric generated from a
+  request when an exception handling middleware is invoked. One caveat is that
+  this fix does not address the problem for the `http.server.request.duration`
+  metric when running ASP.NET Core 8. ASP.NET Core 8 contains an equivalent fix
+  which should ship in version 8.0.2
+  (see: [dotnet/aspnetcore#52652](https://github.com/dotnet/aspnetcore/pull/52652)).
+  ([#5135](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5135))
+
+  * Fixes scenario when the `net6.0` target of this library is loaded into a
+  .NET 7+ process and the instrumentation does not behave as expected. This
+  is an unusual scenario that does not affect users consuming this package
+  normally. This fix is primarily to support the
+  [opentelemetry-dotnet-instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5252)
+  project.
+  ([#5252](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5252))
+
+* Use 1.7.1 of HTTP instrumentation.
+  * .NET Framework - fix description for `http.client.request.duration` metric.
+  ([#5234](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5234))
+
 ### New features
 
 * [#81](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/81)

--- a/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
+++ b/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
@@ -34,13 +34,13 @@
   <!-- Stable instrumentation packages -->
   <ItemGroup>
     <PackageReference Include="MySql.Data.OpenTelemetry" Version="8.2.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.5.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.7.0" />
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with no dependencies -->
   <ItemGroup>
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.6.0-beta.3" />
 

--- a/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
+++ b/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
@@ -62,7 +62,7 @@
 
   <!-- Non-stable instrumentation packages with dependencies, only .NET -->
   <ItemGroup Condition=" '$(TargetFramework)' != 'net462' ">
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.1" />
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with dependencies, only .NET framework -->


### PR DESCRIPTION
## Changes

Upgrades ASP.NET Core an HTTP instrumentation to 1.7.1, Runtime to 1.7.0

## Merge requirement checklist

* [ ] ~Unit tests added/updated~
* [x] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
