### PR TITLE
Add missing `new` before `Uri` in ExporterSettings

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,7 +124,7 @@ using var tracerProvider = Sdk.CreateTracerProviderBuilder()
         config.ExporterSettings = new OtlpExporter
         {
             Protocol = OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf,
-            Endpoint = Uri("https://otlp-gateway-prod-eu-west-0.grafana.net/otlp"),
+            Endpoint = new Uri("https://otlp-gateway-prod-eu-west-0.grafana.net/otlp"),
             Headers = "Authorization=Basic a-secret-token"
         };
     })


### PR DESCRIPTION
Fixes a typo

## Changes

I added `new` before `Uri`, allowing the code to compile without modification.

## Merge requirement checklist

* [ ] Unit tests added/updated
* [ ] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
