### PR TITLE
Upgrade to upstream SDK 1.8.1 (+ other dependencies)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,24 +36,21 @@
   * Fix native AoT warnings in `OpenTelemetry.Exporter.OpenTelemetryProtocol`.
   ([#5520](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5520))
 
-* Use 1.8.1 of OpenTelemetry.Instrumentation.Http
-  * Includes fixes from [1.8.0](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/Instrumentation.Http-1.8.0)
-
 * Use 1.8.1 of OpenTelemetry.Instrumentation.AspNetCore
   * Includes fixes from [1.8.0](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/Instrumentation.AspNetCore-1.8.0)
 
+* Use 1.8.1 of OpenTelemetry.Instrumentation.Http
+  * Includes fixes from [1.8.0](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/Instrumentation.Http-1.8.0)
+
 ### New features
+
+* Use 1.8.0-beta.1 of OpenTelemetry.Instrumentation.GrpcNetClient
 
 * Use 1.8.0 of OpenTelemetry.Instrumentation.Runtime
   * `Meter.Version` is set to NuGet package version. ([#1624](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1624))
   * Update `OpenTelemetry.Api` to `1.8.0`. ([#1624](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1624))
 
-* Use 1.8.0-beta.1 of OpenTelemetry.Instrumentation.GrpcNetClient
-
 * Use 1.8.0-beta.1 of OpenTelemetry.Instrumentation.SqlClient
-
-* Use 0.1.0-alpha.3 of OpenTelemetry.ResourceDetectors.ProcessRuntime
-  * Update `OpenTelemetry.Api` to `1.8.0`. ([#1635](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1635))
 
 * Use 0.5.0-beta.5 of OpenTelemetry.Instrumentation.Process
   * `Meter.Version` is set to NuGet package version. ([#1624](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1624))
@@ -63,6 +60,9 @@
   * Update `OpenTelemetry.Api` to `1.8.0`. ([#1635](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1635))
 
 * Use 0.1.0-alpha.3 of OpenTelemetry.ResourceDetectors.Host
+  * Update `OpenTelemetry.Api` to `1.8.0`. ([#1635](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1635))
+
+* Use 0.1.0-alpha.3 of OpenTelemetry.ResourceDetectors.ProcessRuntime
   * Update `OpenTelemetry.Api` to `1.8.0`. ([#1635](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1635))
 
 ## 0.7.0-beta.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@
 
 ### New features
 
+* Use 1.8.0 of OpenTelemetry.Exporter.Console
+  * Added support for `ActivitySource.Version` property. ([#5472](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5472))
+
 * Use 1.8.0-beta.1 of OpenTelemetry.Instrumentation.GrpcNetClient
 
 * Use 1.8.0 of OpenTelemetry.Instrumentation.Runtime

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,70 @@
 # Changelog
 
+## Unreleased
+
+### BREAKING CHANGES
+
+* Use 1.8.1 of OpenTelemetry.Instrumentation.Http
+  * **Breaking Change**: Fixed tracing instrumentation so that by default any
+  values detected in the query string component of requests are replaced with
+  the text `Redacted` when building the `url.full` tag. For example,
+  `?key1=value1&key2=value2` becomes `?key1=Redacted&key2=Redacted`. You can
+  disable this redaction by setting the environment variable
+  `OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION` to `true`.
+  ([#5532](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5532))
+
+* Use 1.8.1 of OpenTelemetry.Instrumentation.AspNetCore
+  * **Breaking Change**: Fixed tracing instrumentation so that by default any
+  values detected in the query string component of requests are replaced with
+  the text `Redacted` when building the `url.full` tag. For example,
+  `?key1=value1&key2=value2` becomes `?key1=Redacted&key2=Redacted`. You can
+  disable this redaction by setting the environment variable
+  `OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION` to `true`.
+  ([#5532](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5532))
+
+### Bug Fixes
+
+* Use 1.8.1 of OpenTelemetry
+  * Fixed an issue in Logging where unwanted objects (processors, exporters, etc.)
+  could be created inside delegates automatically executed by the Options API
+  during configuration reload.
+  ([#5514](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5514))
+  * Include changes from the following versions:
+    * [1.8.0](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.8.0)
+
+* Use 1.8.1 of OpenTelemetry.Exporter.OpenTelemetryProtocol
+  * Fix native AoT warnings in `OpenTelemetry.Exporter.OpenTelemetryProtocol`.
+  ([#5520](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5520))
+
+* Use 1.8.1 of OpenTelemetry.Instrumentation.Http
+  * Includes fixes from [1.8.0](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/Instrumentation.Http-1.8.0)
+
+* Use 1.8.1 of OpenTelemetry.Instrumentation.AspNetCore
+  * Includes fixes from [1.8.0](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/Instrumentation.AspNetCore-1.8.0)
+
+### New features
+
+* Use 1.8.0 of OpenTelemetry.Instrumentation.Runtime
+  * `Meter.Version` is set to NuGet package version. ([#1624](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1624))
+  * Update `OpenTelemetry.Api` to `1.8.0`. ([#1624](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1624))
+
+* Use 1.8.0-beta.1 of OpenTelemetry.Instrumentation.GrpcNetClient
+
+* Use 1.8.0-beta.1 of OpenTelemetry.Instrumentation.SqlClient
+
+* Use 0.1.0-alpha.3 of OpenTelemetry.ResourceDetectors.ProcessRuntime
+  * Update `OpenTelemetry.Api` to `1.8.0`. ([#1635](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1635))
+
+* Use 0.5.0-beta.5 of OpenTelemetry.Instrumentation.Process
+  * `Meter.Version` is set to NuGet package version. ([#1624](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1624))
+  * Update `OpenTelemetry.Api` to `1.8.0`. ([#1624](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1624))
+
+* Use 1.0.0-beta.6 of OpenTelemetry.ResourceDetectors.Azure
+  * Update `OpenTelemetry.Api` to `1.8.0`. ([#1635](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1635))
+
+* Use 0.1.0-alpha.3 of OpenTelemetry.ResourceDetectors.Host
+  * Update `OpenTelemetry.Api` to `1.8.0`. ([#1635](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1635))
+
 ## 0.7.0-beta.4
 
 ### Bug fixes

--- a/examples/net6.0/aspnetcore/aspnetcore.csproj
+++ b/examples/net6.0/aspnetcore/aspnetcore.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.4" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/examples/net8.0/aspnetcore/aspnetcore.csproj
+++ b/examples/net8.0/aspnetcore/aspnetcore.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.4" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.7.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.8.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
+++ b/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
@@ -27,22 +27,22 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OpenTelemetry" Version="1.7.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
   </ItemGroup>
 
   <!-- Stable instrumentation packages -->
   <ItemGroup>
     <PackageReference Include="MySql.Data.OpenTelemetry" Version="8.2.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with no dependencies -->
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.8.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.6.0-beta.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.8.0-beta.1" />
 
     <PackageReference Include="OpenTelemetry.ResourceDetectors.AWS" Version="1.4.0-beta.1" />
     <PackageReference Include="OpenTelemetry.ResourceDetectors.Azure" Version="1.0.0-beta.4" />
@@ -53,7 +53,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
     <PackageReference Include="OpenTelemetry.ResourceDetectors.Host" Version="0.1.0-alpha.2" />
     <PackageReference Include="OpenTelemetry.ResourceDetectors.Process" Version="0.1.0-alpha.2" />
-    <PackageReference Include="OpenTelemetry.ResourceDetectors.ProcessRuntime" Version="0.1.0-alpha.2" />
+    <PackageReference Include="OpenTelemetry.ResourceDetectors.ProcessRuntime" Version="0.1.0-alpha.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
+++ b/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
@@ -44,16 +44,16 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.5" />
     <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.8.0-beta.1" />
 
-    <PackageReference Include="OpenTelemetry.ResourceDetectors.AWS" Version="1.4.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.ResourceDetectors.Azure" Version="1.0.0-beta.6" />
+    <PackageReference Include="OpenTelemetry.ResourceDetectors.Azure" Version="1.0.0-beta.4" />
     <PackageReference Include="OpenTelemetry.ResourceDetectors.Container" Version="1.0.0-beta.5" />
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with no dependencies, non netstandard2.0 -->
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <PackageReference Include="OpenTelemetry.ResourceDetectors.Host" Version="0.1.0-alpha.3" />
-    <PackageReference Include="OpenTelemetry.ResourceDetectors.Process" Version="0.1.0-alpha.3" />
-    <PackageReference Include="OpenTelemetry.ResourceDetectors.ProcessRuntime" Version="0.1.0-alpha.3" />
+    <PackageReference Include="OpenTelemetry.ResourceDetectors.AWS" Version="1.4.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.ResourceDetectors.Host" Version="0.1.0-alpha.2" />
+    <PackageReference Include="OpenTelemetry.ResourceDetectors.Process" Version="0.1.0-alpha.2" />
+    <PackageReference Include="OpenTelemetry.ResourceDetectors.ProcessRuntime" Version="0.1.0-alpha.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
+++ b/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
@@ -41,18 +41,18 @@
   <ItemGroup>
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.8.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.5" />
     <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.8.0-beta.1" />
 
     <PackageReference Include="OpenTelemetry.ResourceDetectors.AWS" Version="1.4.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.ResourceDetectors.Azure" Version="1.0.0-beta.4" />
+    <PackageReference Include="OpenTelemetry.ResourceDetectors.Azure" Version="1.0.0-beta.6" />
     <PackageReference Include="OpenTelemetry.ResourceDetectors.Container" Version="1.0.0-beta.5" />
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with no dependencies, non netstandard2.0 -->
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <PackageReference Include="OpenTelemetry.ResourceDetectors.Host" Version="0.1.0-alpha.2" />
-    <PackageReference Include="OpenTelemetry.ResourceDetectors.Process" Version="0.1.0-alpha.2" />
+    <PackageReference Include="OpenTelemetry.ResourceDetectors.Host" Version="0.1.0-alpha.3" />
+    <PackageReference Include="OpenTelemetry.ResourceDetectors.Process" Version="0.1.0-alpha.3" />
     <PackageReference Include="OpenTelemetry.ResourceDetectors.ProcessRuntime" Version="0.1.0-alpha.3" />
   </ItemGroup>
 

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/AWSResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/AWSResource.cs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if !NETSTANDARD
 using OpenTelemetry.ResourceDetectors.AWS;
 using OpenTelemetry.Resources;
 
@@ -15,7 +16,7 @@ namespace Grafana.OpenTelemetry
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
             return builder
-#if !NETFRAMEWORK && !NETSTANDARD
+#if !NETFRAMEWORK
                 .AddDetector(new AWSECSResourceDetector())
                 .AddDetector(new AWSEKSResourceDetector())
 #endif
@@ -24,3 +25,4 @@ namespace Grafana.OpenTelemetry
         }
     }
 }
+#endif

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/InstrumentationInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/InstrumentationInitializer.cs
@@ -35,10 +35,10 @@ namespace Grafana.OpenTelemetry
             new SqlClientInitializer(),
             new StackExchangeRedisInitializer(),
             new WcfInitializer(),
-            new AWSResourceInitializer(),
             new AzureResourceInitializer(),
             new ContainerResourceInitializer(),
 #if !NETSTANDARD
+            new AWSResourceInitializer(),
             new HostResourceInitializer(),
             new ProcessResourceInitializer(),
             new ProcessRuntimeResourceInitializer()

--- a/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
+++ b/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
@@ -43,7 +43,7 @@
 
   <!-- Stable instrumentation packages with dependencies, only .NET -->
   <ItemGroup Condition=" '$(TargetFramework)' != 'net462' ">
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" /> <!-- needed for AspNetCore -->
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" /> <!-- needed for AspNetCore -->
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with dependencies, both .NET framework and .NET -->
@@ -52,7 +52,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.2.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Cassandra" Version="1.0.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.ElasticsearchClient" Version="1.0.0-beta.5" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.8" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.11" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.5.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.MySqlData" Version="1.0.0-beta.7" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.0.0-alpha.3" />
@@ -62,7 +62,7 @@
 
   <!-- Non-stable instrumentation packages with dependencies, only .NET -->
   <ItemGroup Condition=" '$(TargetFramework)' != 'net462' ">
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with dependencies, only .NET framework -->

--- a/src/Grafana.OpenTelemetry/OpenTelemetryBuilderExtension.cs
+++ b/src/Grafana.OpenTelemetry/OpenTelemetryBuilderExtension.cs
@@ -21,10 +21,10 @@ namespace Grafana.OpenTelemetry
         /// <summary>
         /// Sets up tracing and metrics with the OpenTelemetry .NET distribution for Grafana.
         /// </summary>
-        /// <param name="builder">A <see cref="OpenTelemetryBuilder"/></param>
+        /// <param name="builder">A <see cref="IOpenTelemetryBuilder"/></param>
         /// <param name="configure">A callback for customizing default Grafana OpenTelemetry settings</param>
-        /// <returns>A modified <see cref="OpenTelemetryBuilder"/> </returns>
-        public static OpenTelemetryBuilder UseGrafana(this OpenTelemetryBuilder builder, Action<GrafanaOpenTelemetrySettings> configure = default)
+        /// <returns>A modified <see cref="IOpenTelemetryBuilder"/> </returns>
+        public static IOpenTelemetryBuilder UseGrafana(this IOpenTelemetryBuilder builder, Action<GrafanaOpenTelemetrySettings> configure = default)
         {
             return builder
                 .WithTracing(tracerProviderBuilder => tracerProviderBuilder.UseGrafana(configure))


### PR DESCRIPTION
## Changes

Upgrades SDK to 1.8.1 plus other packages that were out of date:
* Microsoft.Data.SqlClient
* OpenTelemetry.Exporter.Console
* OpenTelemetry.Exporter.OpenTelemetryProtocol
* OpenTelemetry.Extensions.Hosting
* OpenTelemetry.Instrumentation.AspNetCore
* OpenTelemetry.Instrumentation.EntityFrameworkCore
* OpenTelemetry.Instrumentation.GrpcNetClient
* OpenTelemetry.Instrumentation.Http
* OpenTelemetry.Instrumentation.Process
* OpenTelemetry.Instrumentation.Runtime

## Merge requirement checklist

* [ ] Unit tests added/updated
* [ ] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
