### PR TITLE
Upgrade to upstream SDK 1.9.0 (+ other dependencies)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,7 +146,7 @@
     ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
   * Add support for instrumenting `IConnectionMultiplexer`
     which is added with service key.
-    ([#1885](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1885))  
+    ([#1885](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1885))
 * Use 1.9.0-beta.1 of OpenTelemetry.Instrumentation.SqlClient
   * Updated OpenTelemetry core component version(s) to `1.9.0`.
     ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,174 @@
 # Changelog
 
+## Unreleased
+
+### BREAKING CHANGES
+
+* Use 0.5.0-beta.6 of OpenTelemetry.Instrumentation.Process
+  * **Breaking Change**: Renamed package from `OpenTelemetry.ResourceDetectors.Process`
+    to `OpenTelemetry.Resources.Process`.
+    ([#1717](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1717))
+  * **Breaking Change**: `ProcessDetector` type is now internal, use `ResourceBuilder`
+    extension method `AddProcessDetector` to enable the detector.
+    ([#1717](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1717))
+* Use 1.0.0-beta.8 of OpenTelemetry.Resources.Azure
+  * **Breaking Change**: Renamed method from `AddAppServiceDetector`
+    to `AddAzureAppServiceDetector`.
+    ([#1883](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1883))
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+  * **Breaking Change**: Renamed package from `OpenTelemetry.ResourceDetectors.Azure`
+  to `OpenTelemetry.Resources.Azure`.
+  ([#1840](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1840))
+  * **Breaking Change**: `AppServiceResourceDetector` type is now internal, use `ResourceBuilder`
+    extension method `AddAppServiceDetector` to enable the detector.
+    ([#1840](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1840))
+  * **Breaking Change**: `AzureVMResourceDetector` type is now internal, use `ResourceBuilder`
+    extension method `AddAzureVMResourceDetector` to enable the detector.
+    ([#1840](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1840))
+  * **Breaking Change**: `AzureContainerAppsResourceDetector` type is now
+    internal, use `ResourceBuilder` extension method `AddAzureContainerAppsResourceDetector`
+    to enable the detector.
+    ([#1840](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1840))
+* Use 1.5.0-beta.1 of OpenTelemetry.Resources.AWS
+  * **Breaking Change**: Renamed package from `OpenTelemetry.ResourceDetectors.AWS`
+    to `OpenTelemetry.Resources.AWS`.
+    ([#1839](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1839))
+  * **Breaking Change**: `AWSEBSResourceDetector`, `AWSEC2ResourceDetector`,
+  `AWSECSResourceDetector` and `AWSEKSResourceDetector` types are now internal,
+  use `ResourceBuilder` extension methods `AddAWSEBSDetector`,
+  `AddAWSEC2Detector`, `AddAWSECSDetector`
+  and `AddAWSEKSDetector` respectively to enable the detectors.
+    ([#1839](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1839))
+  * **Breaking Change**: Renamed EventSource
+  from `OpenTelemetry-ResourceDetectors-AWS`
+  to `OpenTelemetry-Resources-AWS`.
+    ([#1839](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1839))
+* Use 0.1.0-beta.2 of OpenTelemetry.Resources.Host
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+  * **Breaking Change**: Renamed package from `OpenTelemetry.ResourceDetectors.Host`
+    to `OpenTelemetry.Resources.Host`.
+    ([#1820](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1820))
+  * **Breaking Change**: `HostDetector` type is now internal, use `ResourceBuilder`
+    extension method `AddHostDetector` to enable the detector.
+    ([#1820](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1820))
+* Use 0.1.0-beta.2 of OpenTelemetry.Resources.Process
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+  * **Breaking Change**: Renamed package from `OpenTelemetry.ResourceDetectors.Process`
+  to `OpenTelemetry.Resources.Process`.
+  ([#1717](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1717))
+  * **Breaking Change**: `ProcessDetector` type is now internal, use `ResourceBuilder`
+  extension method `AddProcessDetector` to enable the detector.
+  ([#1717](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1717))
+* Use 0.1.0-beta.2 of OpenTelemetry.Resources.ProcessRuntime
+  * **Breaking Change**: Renamed package from `OpenTelemetry.ResourceDetectors.ProcessRuntime`
+    to `OpenTelemetry.Resources.ProcessRuntime`.
+    ([#1767](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1767))
+  * **Breaking Change**: `ProcessRuntimeDetector` type is now internal, use `ResourceBuilder`
+    extension method `AddProcessRuntimeDetector` to enable the detector.
+    ([#1767](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1767))
+* Use 1.0.0-beta.9 of OpenTelemetry.Resources.Container
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+  * **Breaking Change**: Renamed package from `OpenTelemetry.ResourceDetectors.Container`
+    to `OpenTelemetry.Resources.Container`.
+    ([#1849](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1849))
+  * **Breaking Change**: `ContainerResourceDetector` type is now internal,
+  use `ResourceBuilder` extension method `AddContainerDetector`
+  to enable the detector.
+    ([#1849](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1849))
+  * **Breaking Change**: Renamed EventSource
+  from `OpenTelemetry-ResourceDetectors-Container`
+  to `OpenTelemetry-Resources-Container`.
+    ([#1849](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1849))
+
+### Bug Fixes
+
+* Use 1.9.0 of OpenTelemetry
+  * Fixed a race condition for the experimental MetricPoint reclaim scenario
+    (enabled via `OTEL_DOTNET_EXPERIMENTAL_METRICS_RECLAIM_UNUSED_METRIC_POINTS`)
+    which could have led to a measurement being dropped.
+    ([#5546](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5546))
+  * Fixed the nullable annotations for the `SamplingResult` constructors
+    to allow `null` being supplied as `attributes` or `traceStateString`
+    which has always been supported.
+    ([#5614](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5614))
+* Use 1.0.0-rc.6 of OpenTelemetry.Instrumentation.Owin
+  * Massive memory leak in OwinInstrumentationMetrics addressed.
+    Made both Meter and Histogram singletons.
+    ([#1655](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1655))
+
+### New features
+
+* Use 1.9.0 of OpenTelemetry.Exporter.OpenTelemetryProtocol
+  * `User-Agent` header format changed from
+    `OTel-OTLP-Exporter-Dotnet/{NuGet Package Version}+{Commit Hash}`
+    to `OTel-OTLP-Exporter-Dotnet/{NuGet Package Version}`.
+    ([#5528](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5528))
+  * Implementation of [OTLP
+    specification](https://github.com/open-telemetry/opentelemetry-proto/blob/v1.2.0/opentelemetry/proto/trace/v1/trace.proto#L112-L133)
+    for propagating `Span` and `SpanLink` flags containing W3C trace flags and
+    `parent_is_remote` information.
+    ([#5563](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5563))
+* Use 1.9.0 of OpenTelemetry.Instrumentation.Runtime
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Use 1.9.0-beta.1 of OpenTelemetry.Instrumentation.GrpcNetClient
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Use 1.9.0 of OpenTelemetry.Instrumentation.Http
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Use 0.5.0-beta.6 of OpenTelemetry.Instrumentation.Process
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Use 1.9.0-beta.1 of OpenTelemetry.Instrumentation.SqlClient
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Use 1.5.0-beta.1 of OpenTelemetry.Resources.AWS
+  * Implement support for cloud.{account.id,availability_zone,region} attributes in
+    AWS ECS detector.
+    ([#1552](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1552))
+  * Implement support for `cloud.resource_id` attribute in AWS ECS detector.
+    ([#1576](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1576))
+  * Update OpenTelemetry SDK version to `1.8.1`.
+    ([#1668](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1668))
+* Use 0.1.0-beta.2 of OpenTelemetry.Resources.Host
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+  * Adds support for `host.id` resource attribute on non-containerized systems.
+  `host.id` will be set per [semantic convention rules](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/resource/host.md)
+    ([#1631](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1631))
+* Use 0.1.0-beta.2 of OpenTelemetry.Resources.Process
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Use 1.0.0-beta.9 of OpenTelemetry.Resources.Container
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Use 1.9.0 of OpenTelemetry.Extensions.Hosting
+* Use 1.1.0-beta.4 of OpenTelemetry.Instrumentation.AWS
+* Use 1.0.0-beta.12 of OpenTelemetry.Instrumentation.EntityFrameworkCore
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Use 1.6.0-beta.1 of OpenTelemetry.Instrumentation.Hangfire
+* Use 1.0.0-beta.3 of OpenTelemetry.Instrumentation.Quartz
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Use 1.0.0-rc9.15 of OpenTelemetry.Instrumentation.StackExchangeRedis
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Use 1.0.0-rc.17 of OpenTelemetry.Instrumentation.Wcf
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Use 1.9.0 of OpenTelemetry.Instrumentation.AspNetCore
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Use 1.9.0-beta.1 of OpenTelemetry.Instrumentation.AspNet
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Use 1.3.0-beta.1 of OpenTelemetry.Instrumentation.AWSLambda
+
 ## 0.8.2-beta.1
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,10 @@
   * Massive memory leak in OwinInstrumentationMetrics addressed.
     Made both Meter and Histogram singletons.
     ([#1655](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1655))
+* Use 1.9.0-beta.1 of OpenTelemetry.Instrumentation.StackExchangeRedis
+  * Update `StackExchange.Redis` version to `2.6.122`, resolving warnings about
+    [CVE-2021-24112](https://github.com/advisories/GHSA-rxg9-xrhp-64gj).
+    ([#1961](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1961))
 
 ### New features
 
@@ -137,9 +141,12 @@
 * Use 1.9.0 of OpenTelemetry.Instrumentation.Runtime
   * Updated OpenTelemetry core component version(s) to `1.9.0`.
     ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
-* Use 1.0.0-rc9.15 of OpenTelemetry.Instrumentation.StackExchangeRedis
+* Use 1.9.0-beta.1 of OpenTelemetry.Instrumentation.StackExchangeRedis
   * Updated OpenTelemetry core component version(s) to `1.9.0`.
     ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+  * Add support for instrumenting `IConnectionMultiplexer`
+    which is added with service key.
+    ([#1885](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1885))  
 * Use 1.9.0-beta.1 of OpenTelemetry.Instrumentation.SqlClient
   * Updated OpenTelemetry core component version(s) to `1.9.0`.
     ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@
   * **Breaking Change**: `ProcessDetector` type is now internal, use `ResourceBuilder`
     extension method `AddProcessDetector` to enable the detector.
     ([#1717](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1717))
+* Use 1.5.0-beta.1 of OpenTelemetry.Resources.AWS
+  * **Breaking Change**: Renamed package from `OpenTelemetry.ResourceDetectors.AWS`
+    to `OpenTelemetry.Resources.AWS`.
+    ([#1839](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1839))
+  * **Breaking Change**: `AWSEBSResourceDetector`, `AWSEC2ResourceDetector`,
+  `AWSECSResourceDetector` and `AWSEKSResourceDetector` types are now internal,
+  use `ResourceBuilder` extension methods `AddAWSEBSDetector`,
+  `AddAWSEC2Detector`, `AddAWSECSDetector`
+  and `AddAWSEKSDetector` respectively to enable the detectors.
+    ([#1839](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1839))
+  * **Breaking Change**: Renamed EventSource
+  from `OpenTelemetry-ResourceDetectors-AWS`
+  to `OpenTelemetry-Resources-AWS`.
+    ([#1839](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1839))
 * Use 1.0.0-beta.8 of OpenTelemetry.Resources.Azure
   * **Breaking Change**: Renamed method from `AddAppServiceDetector`
     to `AddAzureAppServiceDetector`.
@@ -30,20 +44,20 @@
     internal, use `ResourceBuilder` extension method `AddAzureContainerAppsResourceDetector`
     to enable the detector.
     ([#1840](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1840))
-* Use 1.5.0-beta.1 of OpenTelemetry.Resources.AWS
-  * **Breaking Change**: Renamed package from `OpenTelemetry.ResourceDetectors.AWS`
-    to `OpenTelemetry.Resources.AWS`.
-    ([#1839](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1839))
-  * **Breaking Change**: `AWSEBSResourceDetector`, `AWSEC2ResourceDetector`,
-  `AWSECSResourceDetector` and `AWSEKSResourceDetector` types are now internal,
-  use `ResourceBuilder` extension methods `AddAWSEBSDetector`,
-  `AddAWSEC2Detector`, `AddAWSECSDetector`
-  and `AddAWSEKSDetector` respectively to enable the detectors.
-    ([#1839](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1839))
+* Use 1.0.0-beta.9 of OpenTelemetry.Resources.Container
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+  * **Breaking Change**: Renamed package from `OpenTelemetry.ResourceDetectors.Container`
+    to `OpenTelemetry.Resources.Container`.
+    ([#1849](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1849))
+  * **Breaking Change**: `ContainerResourceDetector` type is now internal,
+  use `ResourceBuilder` extension method `AddContainerDetector`
+  to enable the detector.
+    ([#1849](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1849))
   * **Breaking Change**: Renamed EventSource
-  from `OpenTelemetry-ResourceDetectors-AWS`
-  to `OpenTelemetry-Resources-AWS`.
-    ([#1839](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1839))
+  from `OpenTelemetry-ResourceDetectors-Container`
+  to `OpenTelemetry-Resources-Container`.
+    ([#1849](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1849))
 * Use 0.1.0-beta.2 of OpenTelemetry.Resources.Host
     ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
   * **Breaking Change**: Renamed package from `OpenTelemetry.ResourceDetectors.Host`
@@ -68,20 +82,6 @@
   * **Breaking Change**: `ProcessRuntimeDetector` type is now internal, use `ResourceBuilder`
     extension method `AddProcessRuntimeDetector` to enable the detector.
     ([#1767](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1767))
-* Use 1.0.0-beta.9 of OpenTelemetry.Resources.Container
-  * Updated OpenTelemetry core component version(s) to `1.9.0`.
-    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
-  * **Breaking Change**: Renamed package from `OpenTelemetry.ResourceDetectors.Container`
-    to `OpenTelemetry.Resources.Container`.
-    ([#1849](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1849))
-  * **Breaking Change**: `ContainerResourceDetector` type is now internal,
-  use `ResourceBuilder` extension method `AddContainerDetector`
-  to enable the detector.
-    ([#1849](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1849))
-  * **Breaking Change**: Renamed EventSource
-  from `OpenTelemetry-ResourceDetectors-Container`
-  to `OpenTelemetry-Resources-Container`.
-    ([#1849](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1849))
 
 ### Bug Fixes
 
@@ -111,19 +111,39 @@
     for propagating `Span` and `SpanLink` flags containing W3C trace flags and
     `parent_is_remote` information.
     ([#5563](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5563))
-* Use 1.9.0 of OpenTelemetry.Instrumentation.Runtime
+* Use 1.9.0 of OpenTelemetry.Extensions.Hosting
+* Use 1.9.0-beta.1 of OpenTelemetry.Instrumentation.AspNet
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Use 1.9.0 of OpenTelemetry.Instrumentation.AspNetCore
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Use 1.1.0-beta.4 of OpenTelemetry.Instrumentation.AWS
+* Use 1.3.0-beta.1 of OpenTelemetry.Instrumentation.AWSLambda
+* Use 1.0.0-beta.12 of OpenTelemetry.Instrumentation.EntityFrameworkCore
   * Updated OpenTelemetry core component version(s) to `1.9.0`.
     ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
 * Use 1.9.0-beta.1 of OpenTelemetry.Instrumentation.GrpcNetClient
   * Updated OpenTelemetry core component version(s) to `1.9.0`.
     ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Use 1.6.0-beta.1 of OpenTelemetry.Instrumentation.Hangfire
 * Use 1.9.0 of OpenTelemetry.Instrumentation.Http
   * Updated OpenTelemetry core component version(s) to `1.9.0`.
     ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
 * Use 0.5.0-beta.6 of OpenTelemetry.Instrumentation.Process
   * Updated OpenTelemetry core component version(s) to `1.9.0`.
     ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Use 1.0.0-beta.3 of OpenTelemetry.Instrumentation.Quartz
+* Use 1.9.0 of OpenTelemetry.Instrumentation.Runtime
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Use 1.0.0-rc9.15 of OpenTelemetry.Instrumentation.StackExchangeRedis
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
 * Use 1.9.0-beta.1 of OpenTelemetry.Instrumentation.SqlClient
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Use 1.0.0-rc.17 of OpenTelemetry.Instrumentation.Wcf
   * Updated OpenTelemetry core component version(s) to `1.9.0`.
     ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
 * Use 1.5.0-beta.1 of OpenTelemetry.Resources.AWS
@@ -134,6 +154,9 @@
     ([#1576](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1576))
   * Update OpenTelemetry SDK version to `1.8.1`.
     ([#1668](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1668))
+* Use 1.0.0-beta.9 of OpenTelemetry.Resources.Container
+  * Updated OpenTelemetry core component version(s) to `1.9.0`.
+    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
 * Use 0.1.0-beta.2 of OpenTelemetry.Resources.Host
   * Updated OpenTelemetry core component version(s) to `1.9.0`.
     ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
@@ -143,31 +166,11 @@
 * Use 0.1.0-beta.2 of OpenTelemetry.Resources.Process
   * Updated OpenTelemetry core component version(s) to `1.9.0`.
     ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
-* Use 1.0.0-beta.9 of OpenTelemetry.Resources.Container
+
+
+
   * Updated OpenTelemetry core component version(s) to `1.9.0`.
     ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
-* Use 1.9.0 of OpenTelemetry.Extensions.Hosting
-* Use 1.1.0-beta.4 of OpenTelemetry.Instrumentation.AWS
-* Use 1.0.0-beta.12 of OpenTelemetry.Instrumentation.EntityFrameworkCore
-  * Updated OpenTelemetry core component version(s) to `1.9.0`.
-    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
-* Use 1.6.0-beta.1 of OpenTelemetry.Instrumentation.Hangfire
-* Use 1.0.0-beta.3 of OpenTelemetry.Instrumentation.Quartz
-  * Updated OpenTelemetry core component version(s) to `1.9.0`.
-    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
-* Use 1.0.0-rc9.15 of OpenTelemetry.Instrumentation.StackExchangeRedis
-  * Updated OpenTelemetry core component version(s) to `1.9.0`.
-    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
-* Use 1.0.0-rc.17 of OpenTelemetry.Instrumentation.Wcf
-  * Updated OpenTelemetry core component version(s) to `1.9.0`.
-    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
-* Use 1.9.0 of OpenTelemetry.Instrumentation.AspNetCore
-  * Updated OpenTelemetry core component version(s) to `1.9.0`.
-    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
-* Use 1.9.0-beta.1 of OpenTelemetry.Instrumentation.AspNet
-  * Updated OpenTelemetry core component version(s) to `1.9.0`.
-    ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
-* Use 1.3.0-beta.1 of OpenTelemetry.Instrumentation.AWSLambda
 
 ## 0.8.2-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,8 +147,8 @@
   * Updated OpenTelemetry core component version(s) to `1.9.0`.
     ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
 * Use 1.5.0-beta.1 of OpenTelemetry.Resources.AWS
-  * Implement support for cloud.{account.id,availability_zone,region} attributes in
-    AWS ECS detector.
+  * Implement support for cloud.{account.id,availability_zone,region} attributes
+    in AWS ECS detector.
     ([#1552](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1552))
   * Implement support for `cloud.resource_id` attribute in AWS ECS detector.
     ([#1576](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1576))
@@ -166,9 +166,6 @@
 * Use 0.1.0-beta.2 of OpenTelemetry.Resources.Process
   * Updated OpenTelemetry core component version(s) to `1.9.0`.
     ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
-
-
-
   * Updated OpenTelemetry core component version(s) to `1.9.0`.
     ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
 

--- a/docs/supported-instrumentations.md
+++ b/docs/supported-instrumentations.md
@@ -10,20 +10,20 @@ and [minimal](./installation.md#install-the-base-package) dependencies:
 | `AspNetCore`          | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.AspNetCore](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNetCore) |
 | `AWS`                 | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.AWS](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AWS) |
 | `AWSLambda`           | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.AWSLambda](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AWSLambda) |
-| `AWSResource`         | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.ResourceDetectors.AWS](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.ResourceDetectors.AWS) |
-| `AzureResource`       | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.ResourceDetectors.Azure](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.ResourceDetectors.Azure) |
+| `AWSResource`         | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Resources.AWS](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Resources.AWS) |
+| `AzureResource`       | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Resources.Azure](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Resources.Azure) |
 | `Cassandra`           | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.Cassandra](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Cassandra) |
-| `ContainerResource`   | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.ResourceDetectors.Container](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.ResourceDetectors.Container) |
+| `ContainerResource`   | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Resources.Container](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Resources.Container) |
 | `ElasticsearchClient` | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.ElasticsearchClient](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.ElasticsearchClient) |
 | `EntityFrameworkCore` | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.EntityFrameworkCore](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.EntityFrameworkCore) |
 | `GrpcNetClient`       | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Instrumentation.GrpcNetClient](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.GrpcNetClient) |
 | `Hangfire`            | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.Hangfire](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Hangfire) |
 | `HttpClient`          | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Instrumentation.Http](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Http) |
-| `HostResource`        | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.ResourceDetectors.Host](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Resources.Host) |
+| `HostResource`        | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Resources.Host](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Resources.Host) |
 | `NetRuntime`          | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Instrumentation.Runtime](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Runtime) |
 | `Process`             | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Instrumentation.Process](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Process) |
-| `ProcessResource`     | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.ResourceDetectors.Process](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Resources.Process) |
-| `ProcessRuntimeResource`| :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.ResourceDetectors.ProcessRuntime](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Resources.ProcessRuntime) |
+| `ProcessResource`     | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Resources.Process](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Resources.Process) |
+| `ProcessRuntimeResource`| :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Resources.ProcessRuntime](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Resources.ProcessRuntime) |
 | `MySqlData`           | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Instrumentation.MySqlData](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.MySqlData) |
 |                       | :heavy_check_mark: |                    | [MySql.Data.OpenTelemetry](https://www.nuget.org/packages/MySql.Data.OpenTelemetry) |
 | `Owin`                | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.Owin](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Owin) |

--- a/examples/net6.0/aspnetcore/aspnetcore.csproj
+++ b/examples/net6.0/aspnetcore/aspnetcore.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/examples/net8.0/aspnetcore/aspnetcore.csproj
+++ b/examples/net8.0/aspnetcore/aspnetcore.csproj
@@ -12,8 +12,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
+++ b/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
@@ -27,33 +27,32 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OpenTelemetry" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
   </ItemGroup>
 
   <!-- Stable instrumentation packages -->
   <ItemGroup>
     <PackageReference Include="MySql.Data.OpenTelemetry" Version="8.2.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with no dependencies -->
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.8.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.5" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.8.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.9.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.6" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.9.0-beta.1" />
 
-    <PackageReference Include="OpenTelemetry.ResourceDetectors.Azure" Version="1.0.0-beta.4" />
-    <PackageReference Include="OpenTelemetry.ResourceDetectors.Container" Version="1.0.0-beta.5" />
+    <PackageReference Include="OpenTelemetry.Resources.Azure" Version="1.0.0-beta.8" />
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with no dependencies, non netstandard2.0 -->
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <PackageReference Include="OpenTelemetry.ResourceDetectors.AWS" Version="1.4.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.ResourceDetectors.Host" Version="0.1.0-alpha.2" />
-    <PackageReference Include="OpenTelemetry.ResourceDetectors.Process" Version="0.1.0-alpha.2" />
-    <PackageReference Include="OpenTelemetry.ResourceDetectors.ProcessRuntime" Version="0.1.0-alpha.2" />
+    <PackageReference Include="OpenTelemetry.Resources.AWS" Version="1.5.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Resources.Host" Version="0.1.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Resources.Process" Version="0.1.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Resources.ProcessRuntime" Version="0.1.0-beta.2" />
   </ItemGroup>
 
   <ItemGroup>
@@ -64,6 +63,14 @@
 
   <ItemGroup>
     <None Include="../../internal/img/Grafana_icon.png" Pack="true" Visible="false" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.0.0-beta.9" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.0.0-beta.9" />
   </ItemGroup>
 
 </Project>

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/AWSResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/AWSResource.cs
@@ -4,7 +4,6 @@
 //
 
 #if !NETSTANDARD
-using OpenTelemetry.ResourceDetectors.AWS;
 using OpenTelemetry.Resources;
 
 namespace Grafana.OpenTelemetry
@@ -17,11 +16,11 @@ namespace Grafana.OpenTelemetry
         {
             return builder
 #if !NETFRAMEWORK
-                .AddDetector(new AWSECSResourceDetector())
-                .AddDetector(new AWSEKSResourceDetector())
+                .AddAWSECSDetector()
+                .AddAWSEKSDetector()
 #endif
-                .AddDetector(new AWSEC2ResourceDetector())
-                .AddDetector(new AWSEBSResourceDetector());
+                .AddAWSEC2Detector()
+                .AddAWSEBSDetector();
         }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/AzureResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/AzureResource.cs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-using OpenTelemetry.ResourceDetectors.Azure;
 using OpenTelemetry.Resources;
 
 namespace Grafana.OpenTelemetry
@@ -14,7 +13,7 @@ namespace Grafana.OpenTelemetry
 
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
-            return builder.AddDetector(new AppServiceResourceDetector());
+            return builder.AddAzureAppServiceDetector();
         }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/ContainerResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/ContainerResource.cs
@@ -3,8 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-using OpenTelemetry.ResourceDetectors.Container;
 using OpenTelemetry.Resources;
+
+#if NET6_0_OR_GREATER
 
 namespace Grafana.OpenTelemetry
 {
@@ -14,7 +15,9 @@ namespace Grafana.OpenTelemetry
 
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
-            return builder.AddDetector(new ContainerResourceDetector());
+            return builder.AddContainerDetector();
         }
     }
 }
+
+#endif

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/HostResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/HostResource.cs
@@ -5,7 +5,6 @@
 
 #if !NETSTANDARD
 
-using OpenTelemetry.ResourceDetectors.Host;
 using OpenTelemetry.Resources;
 
 namespace Grafana.OpenTelemetry
@@ -16,7 +15,7 @@ namespace Grafana.OpenTelemetry
 
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
-            return builder.AddDetector(new HostDetector());
+            return builder.AddHostDetector();
         }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/InstrumentationInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/InstrumentationInitializer.cs
@@ -36,7 +36,9 @@ namespace Grafana.OpenTelemetry
             new StackExchangeRedisInitializer(),
             new WcfInitializer(),
             new AzureResourceInitializer(),
+#if NET6_0_OR_GREATER
             new ContainerResourceInitializer(),
+#endif
 #if !NETSTANDARD
             new AWSResourceInitializer(),
             new HostResourceInitializer(),

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/ProcessResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/ProcessResource.cs
@@ -5,7 +5,6 @@
 
 #if !NETSTANDARD
 
-using OpenTelemetry.ResourceDetectors.Process;
 using OpenTelemetry.Resources;
 
 namespace Grafana.OpenTelemetry
@@ -16,7 +15,7 @@ namespace Grafana.OpenTelemetry
 
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
-            return builder.AddDetector(new ProcessDetector());
+            return builder.AddProcessDetector();
         }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/ProcessRuntimeResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/ProcessRuntimeResource.cs
@@ -15,7 +15,7 @@ namespace Grafana.OpenTelemetry
 
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
-            return builder.AddProcessDetector();
+            return builder.AddProcessRuntimeDetector();
         }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/ProcessRuntimeResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/ProcessRuntimeResource.cs
@@ -5,7 +5,6 @@
 
 #if !NETSTANDARD
 
-using OpenTelemetry.ResourceDetectors.ProcessRuntime;
 using OpenTelemetry.Resources;
 
 namespace Grafana.OpenTelemetry
@@ -16,7 +15,7 @@ namespace Grafana.OpenTelemetry
 
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
-            return builder.AddDetector(new ProcessRuntimeDetector());
+            return builder.AddProcessDetector();
         }
     }
 }

--- a/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
+++ b/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
@@ -43,32 +43,39 @@
 
   <!-- Stable instrumentation packages with dependencies, only .NET -->
   <ItemGroup Condition=" '$(TargetFramework)' != 'net462' ">
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" /> <!-- needed for AspNetCore -->
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" /> <!-- needed for AspNetCore -->
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with dependencies, both .NET framework and .NET -->
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.1.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.2.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.1.0-beta.4" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Cassandra" Version="1.0.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.ElasticsearchClient" Version="1.0.0-beta.5" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.11" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.5.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.12" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.6.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.MySqlData" Version="1.0.0-beta.7" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.0.0-alpha.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.12" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Wcf" Version="1.0.0-rc.13" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.0.0-beta.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.15" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Wcf" Version="1.0.0-rc.17" />
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with dependencies, only .NET -->
   <ItemGroup Condition=" '$(TargetFramework)' != 'net462' ">
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with dependencies, only .NET framework -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.6.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Owin" Version="1.0.0-rc.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.9.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Owin" Version="1.0.0-rc.6" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.3.0-beta.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.3.0-beta.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
+++ b/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
@@ -55,7 +55,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.6.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.MySqlData" Version="1.0.0-beta.7" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.0.0-beta.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.15" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.9.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Wcf" Version="1.0.0-rc.17" />
   </ItemGroup>
 


### PR DESCRIPTION
## Changes

Upgrades SDK to 1.9.0 plus other packages that were out of date:

* OpenTelemetry.Exporter.OpenTelemetryProtocol
* OpenTelemetry.Extensions.Hosting
* OpenTelemetry.Instrumentation.AspNet
* OpenTelemetry.Instrumentation.AspNetCore
* OpenTelemetry.Instrumentation.AWS
* OpenTelemetry.Instrumentation.AWSLambda
* OpenTelemetry.Instrumentation.EntityFrameworkCore
* OpenTelemetry.Instrumentation.GrpcNetClient
* OpenTelemetry.Instrumentation.Hangfire
* OpenTelemetry.Instrumentation.Http
* OpenTelemetry.Instrumentation.Owin
* OpenTelemetry.Instrumentation.Process
* OpenTelemetry.Instrumentation.Quartz
* OpenTelemetry.Instrumentation.Runtime
* OpenTelemetry.Instrumentation.SqlClient
* OpenTelemetry.Instrumentation.StackExchangeRedis
* OpenTelemetry.Instrumentation.Wcf
* OpenTelemetry.Resources.AWS
* OpenTelemetry.Resources.Azure
* OpenTelemetry.Resources.Container
* OpenTelemetry.Resources.Host
* OpenTelemetry.Resources.Process
* OpenTelemetry.Resources.ProcessRuntime

## Merge requirement checklist

* [ ] Unit tests added/updated
* [x] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
