### PR TITLE
Remove workaround for stable service.instance.id across signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+* Remove workaround for stable `service.instance.id` across signals
+  ([#108](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/108))
+
 ## 0.9.0-beta.1
 
 ### BREAKING CHANGES

--- a/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetrySettings.cs
+++ b/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetrySettings.cs
@@ -19,14 +19,6 @@ namespace Grafana.OpenTelemetry
         internal const string DisableInstrumentationsEnvVarName = "GRAFANA_DOTNET_DISABLE_INSTRUMENTATIONS";
         internal const string ServiceNameEnvVarName = "OTEL_SERVICE_NAME";
 
-        // As a workaround, a static random service instance id is initialized and used as default.
-        // This is to avoid different instance ids to be created by provider builders for different
-        // signals.
-        //
-        // This can be removed once the related issue is resolved:
-        // https://github.com/open-telemetry/opentelemetry-dotnet/issues/4871
-        internal static string DefaultServiceInstanceId = Guid.NewGuid().ToString();
-
         /// <summary>
         /// Gets or sets the exporter settings for sending telemetry data to Grafana.
         ///
@@ -66,7 +58,7 @@ namespace Grafana.OpenTelemetry
         ///
         /// This corresponds to the `service.instance.id` resource attribute.
         /// </summary>
-        public string ServiceInstanceId { get; set; } = DefaultServiceInstanceId;
+        public string ServiceInstanceId { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the deployment environment ("staging" or "production").

--- a/src/Grafana.OpenTelemetry.Base/ResourceBuilderExtension.cs
+++ b/src/Grafana.OpenTelemetry.Base/ResourceBuilderExtension.cs
@@ -11,12 +11,15 @@ namespace Grafana.OpenTelemetry
     {
         public static ResourceBuilder AddGrafanaResource(this ResourceBuilder resourceBuilder, GrafanaOpenTelemetrySettings settings)
         {
+            var serviceInstanceIdProvided = !string.IsNullOrEmpty(settings.ServiceInstanceId);
+
             return resourceBuilder
                 .AddDetector(new GrafanaOpenTelemetryResourceDetector(settings))
                 .AddService(
                     serviceName: settings.ServiceName,
                     serviceVersion: settings.ServiceVersion,
-                    serviceInstanceId: settings.ServiceInstanceId);
+                    serviceInstanceId: serviceInstanceIdProvided ? settings.ServiceInstanceId : null,
+                    autoGenerateServiceInstanceId: serviceInstanceIdProvided == false);
 
         }
     }

--- a/tests/Grafana.OpenTelemetry.Tests/GrafanaOpenTelemetrySettingsTest.cs
+++ b/tests/Grafana.OpenTelemetry.Tests/GrafanaOpenTelemetrySettingsTest.cs
@@ -66,15 +66,6 @@ namespace Grafana.OpenTelemetry.Tests
         }
 
         [Fact]
-        public void StableServiceInstanceId()
-        {
-            var settings1 = new GrafanaOpenTelemetrySettings();
-            var settings2 = new GrafanaOpenTelemetrySettings();
-
-            Assert.Equal(settings1.ServiceInstanceId, settings2.ServiceInstanceId);
-        }
-
-        [Fact]
         public void DefaultServiceName()
         {
             var settings = new GrafanaOpenTelemetrySettings();

--- a/tests/Grafana.OpenTelemetry.Tests/ResourceBuilderExtensionTest.cs
+++ b/tests/Grafana.OpenTelemetry.Tests/ResourceBuilderExtensionTest.cs
@@ -1,0 +1,53 @@
+//
+// Copyright Grafana Labs
+// SPDX-License-Identifier: Apache-2.0
+//
+
+using System.Linq;
+using OpenTelemetry.Resources;
+using Xunit;
+
+namespace Grafana.OpenTelemetry.Tests
+{
+    public class ResourceBuilderExtensionTest
+    {
+        [Fact]
+        public void StableServiceInstanceId()
+        {
+            var resource1 = ResourceBuilder
+                .CreateEmpty()
+                .AddGrafanaResource(new GrafanaOpenTelemetrySettings())
+                .Build()
+                .Attributes
+                .ToDictionary(x => x.Key, x => x.Value);
+            var resource2 = ResourceBuilder
+                .CreateEmpty()
+                .AddGrafanaResource(new GrafanaOpenTelemetrySettings())
+                .Build()
+                .Attributes
+                .ToDictionary(x => x.Key, x => x.Value);
+
+            Assert.NotNull(resource1["service.instance.id"]);
+            Assert.NotNull(resource2["service.instance.id"]);
+            Assert.Equal(resource1["service.instance.id"], resource2["service.instance.id"]);
+        }
+
+        [Fact]
+        public void OverrideServiceInstanceId()
+        {
+            var settings = new GrafanaOpenTelemetrySettings
+            {
+                ServiceInstanceId = "test-id"
+            };
+            var resource1 = ResourceBuilder
+                .CreateEmpty()
+                .AddGrafanaResource(settings)
+                .Build()
+                .Attributes
+                .ToDictionary(x => x.Key, x => x.Value);
+
+            Assert.NotNull(resource1["service.instance.id"]);
+            Assert.Equal(resource1["service.instance.id"], "test-id");
+        }
+    }
+}


### PR DESCRIPTION
## Changes

Remove workaround for stable `service.instance.id` across signals

## Merge requirement checklist

* [x] Unit tests added/updated
* [x] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
