### PR TITLE
Bump Go version for OATs integration tests

### DIFF
--- a/.github/workflows/oats.yml
+++ b/.github/workflows/oats.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: '1.22'
           cache-dependency-path: oats/go.sum
       - name: Run acceptance tests
         run: ./scripts/run-oats-tests.sh


### PR DESCRIPTION
## Changes

Bump Go version for OATs integration tests

## Merge requirement checklist

* ~[ ] Unit tests added/updated~
* ~[ ] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes~
* ~[ ] Changes in public API reviewed (if applicable)~
