### PR TITLE
Removes AWS and Azure cloud resource detectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### BREAKING CHANGES
 
+* Removes AWS and Azure resource detectors.
+  ([#114](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/114))
+* Drops supports for .NET 7. EOL was May 24 2024
+  ([#116](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/116))
 * Separates resource detectors and instrumentations. Removes resource detector
   names from `Grafana.OpenTelemetry.Instrumentation` enumeration. Adds new
   `Grafana.OpenTelemetry.ResourceDetectors` enumeration.

--- a/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
+++ b/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
@@ -49,7 +49,6 @@
 
   <!-- Non-stable instrumentation packages with no dependencies, non netstandard2.0 -->
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <PackageReference Include="OpenTelemetry.Resources.AWS" Version="1.5.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Resources.Host" Version="0.1.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Resources.OperatingSystem" Version="0.1.0-alpha.2" />
     <PackageReference Include="OpenTelemetry.Resources.Process" Version="0.1.0-beta.2" />

--- a/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
+++ b/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
@@ -43,8 +43,6 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.6" />
     <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.9.0-beta.1" />
-
-    <PackageReference Include="OpenTelemetry.Resources.Azure" Version="1.0.0-beta.8" />
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with no dependencies, non netstandard2.0 -->

--- a/src/Grafana.OpenTelemetry.Base/ResourceDetectors/AWSEBSDetectorInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/ResourceDetectors/AWSEBSDetectorInitializer.cs
@@ -14,7 +14,12 @@ namespace Grafana.OpenTelemetry
 
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
-            return builder.AddAWSEBSDetector();
+            ReflectionHelper.CallStaticMethod(
+                "OpenTelemetry.Resources.AWS",
+                "OpenTelemetry.Resources.AWSResourceBuilderExtensions",
+                "AddAWSEBSDetector",
+                new object[] { builder });
+            return builder;
         }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/ResourceDetectors/AWSEC2DetectorInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/ResourceDetectors/AWSEC2DetectorInitializer.cs
@@ -14,7 +14,12 @@ namespace Grafana.OpenTelemetry
 
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
-            return builder.AddAWSEC2Detector();
+            ReflectionHelper.CallStaticMethod(
+                "OpenTelemetry.Resources.AWS",
+                "OpenTelemetry.Resources.AWSResourceBuilderExtensions",
+                "AddAWSEC2Detector",
+                new object[] { builder });
+            return builder;
         }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/ResourceDetectors/AWSECSDetectorInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/ResourceDetectors/AWSECSDetectorInitializer.cs
@@ -14,7 +14,12 @@ namespace Grafana.OpenTelemetry
 
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
-            return builder.AddAWSECSDetector();
+            ReflectionHelper.CallStaticMethod(
+                "OpenTelemetry.Resources.AWS",
+                "OpenTelemetry.Resources.AWSResourceBuilderExtensions",
+                "AddAWSECSDetector",
+                new object[] { builder });
+            return builder;
         }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/ResourceDetectors/AWSEKSDetectorInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/ResourceDetectors/AWSEKSDetectorInitializer.cs
@@ -14,7 +14,12 @@ namespace Grafana.OpenTelemetry
 
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
-            return builder.AddAWSEKSDetector();
+            ReflectionHelper.CallStaticMethod(
+                "OpenTelemetry.Resources.AWS",
+                "OpenTelemetry.Resources.AWSResourceBuilderExtensions",
+                "AddAWSEKSDetector",
+                new object[] { builder });
+            return builder;
         }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/ResourceDetectors/AzureAppServiceDetectorInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/ResourceDetectors/AzureAppServiceDetectorInitializer.cs
@@ -13,7 +13,12 @@ namespace Grafana.OpenTelemetry
 
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
-            return builder.AddAzureAppServiceDetector();
+            ReflectionHelper.CallStaticMethod(
+                "OpenTelemetry.Resources.Azure",
+                "OpenTelemetry.Resources.AzureResourceBuilderExtensions",
+                "AddAzureAppServiceDetector",
+                new object[] { builder });
+            return builder;
         }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/ResourceDetectors/AzureContainerAppsDetectorInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/ResourceDetectors/AzureContainerAppsDetectorInitializer.cs
@@ -13,7 +13,12 @@ namespace Grafana.OpenTelemetry
 
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
-            return builder.AddAzureContainerAppsDetector();
+            ReflectionHelper.CallStaticMethod(
+                "OpenTelemetry.Resources.Azure",
+                "OpenTelemetry.Resources.AzureResourceBuilderExtensions",
+                "AddAzureContainerAppsDetector",
+                new object[] { builder });
+            return builder;
         }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/ResourceDetectors/AzureVMDetectorInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/ResourceDetectors/AzureVMDetectorInitializer.cs
@@ -13,7 +13,12 @@ namespace Grafana.OpenTelemetry
 
         protected override ResourceBuilder InitializeResourceDetector(ResourceBuilder builder)
         {
-            return builder.AddAzureVMDetector();
+            ReflectionHelper.CallStaticMethod(
+                "OpenTelemetry.Resources.Azure",
+                "OpenTelemetry.Resources.AzureResourceBuilderExtensions",
+                "AddAzureVMDetector",
+                new object[] { builder });
+            return builder;
         }
     }
 }


### PR DESCRIPTION
## Changes

Removes AWS and Azure cloud resource detectors. This is a breaking change.

These detectors are being removed from the package to prevent application startup issues. These detectors attempt to determine which cloud platform an application is deployed to, and this can significantly impact startup times.

Configuration documentation changes to follow.

## Merge requirement checklist

* [x] Unit tests added/updated
* [x] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
