### PR TITLE
Removes .NET 7.0 build target and CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false  # ensures the entire test matrix is run, even if one permutation fails
       matrix:
         os: [ windows-latest, ubuntu-latest ]
-        version: [ net462, net6.0, net7.0, net8.0 ]
+        version: [ net462, net6.0, net8.0 ]
         exclude:
         - os: ubuntu-latest
           version: net462

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### BREAKING CHANGES
 
+* Drops supports for .NET 7. EOL was May 24 2024
+  ([#116](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/116))
 * Separates resource detectors and instrumentations. Removes resource detector
   names from `Grafana.OpenTelemetry.Instrumentation` enumeration. Adds new
   `Grafana.OpenTelemetry.ResourceDetectors` enumeration.

--- a/tests/Grafana.OpenTelemetry.Tests/Grafana.OpenTelemetry.Tests.csproj
+++ b/tests/Grafana.OpenTelemetry.Tests/Grafana.OpenTelemetry.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.0;net462</TargetFrameworks>
     <Nullable>disable</Nullable>
 
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
## Changes

Removes .NET 7.0 build target and CI. Support for .NET 7 ended May 24 2024

## Merge requirement checklist

* [ ] Unit tests added/updated
* [x] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
