### PR TITLE
Rename resource detector configuration environment variables

### DIFF
--- a/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetrySettings.cs
+++ b/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetrySettings.cs
@@ -17,8 +17,8 @@ namespace Grafana.OpenTelemetry
     public class GrafanaOpenTelemetrySettings
     {
         internal const string DisableInstrumentationsEnvVarName = "GRAFANA_DOTNET_DISABLE_INSTRUMENTATIONS";
-        internal const string DisableResourceDetectorsEnvVarName = "GRAFANA_DOTNET_DISABLE_RESOURCEDETECTORS";
-        internal const string ResourceDetectorsEnvVarName = "GRAFANA_DOTNET_RESOURCEDETECTORS";
+        internal const string DisableResourceDetectorsEnvVarName = "GRAFANA_DOTNET_DISABLE_RESOURCE_DETECTORS";
+        internal const string ResourceDetectorsEnvVarName = "GRAFANA_DOTNET_RESOURCE_DETECTORS";
         internal const string ServiceNameEnvVarName = "OTEL_SERVICE_NAME";
 
         /// <summary>


### PR DESCRIPTION
## Changes

Rename resource detector configuration environment variables to align with existing scheme (ex OTEL_RESOURCE_ATTRIBUTES, OTEL_NODE_RESOURCE_DETECTORS).

## Merge requirement checklist

* [ ] Unit tests added/updated
* [ ] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
