### PR TITLE
Upgrade to SDK 1.10.0, bump all dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,32 @@
 
 ### New features
 
-* Use 1.10.0-beta.1 of OpenTelemetry.Instrumentation.AWS
-* Use 1.10.0-beta.1 of OpenTelemetry.Instrumentation.AWSLambda
+* Use 3.22.0 of CassandraCSharpDriver
+* Use 9.0.0 of Microsoft.Extensions.Configuration
+* Use 9.0.0 of Microsoft.Extensions.Configuration.EnvironmentVariables
+* Use 9.0.0 of Microsoft.Extensions.Logging
+* Use 1.10.0 of OpenTelemetry
+* Use 1.10.0 of OpenTelemetry.Exporter.OpenTelemetryProtocol
+* Use 1.10.0 of OpenTelemetry.Extensions.Hosting
+* Use 1.10.0 of OpenTelemetry.Instrumentation.Runtime
+* Use 1.10.0 of OpenTelemetry.Instrumentation.Http
+* Use 1.10.0-beta.1 of OpenTelemetry.Instrumentation.AspNet
+* Use 1.10.0-beta.2 of OpenTelemetry.Instrumentation.AWS
+* Use 1.10.0-beta.2 of OpenTelemetry.Instrumentation.AWSLambda
+* Use 1.10.0-beta.2 of OpenTelemetry.Instrumentation.Cassandra
+* Use 1.10.0-beta.1 of OpenTelemetry.Instrumentation.EntityFrameworkCore
+* Use 1.10.0-beta.1 of OpenTelemetry.Instrumentation.GrpcNetClient
+* Use 1.9.0-beta.1 of OpenTelemetry.Instrumentation.HangFire
+* Use 1.10.0-beta.1 of OpenTelemetry.Instrumentation.Process
+* Use 1.10.0-beta.1 of OpenTelemetry.Instrumentation.Quartz
+* Use 1.10.0-beta.1 of OpenTelemetry.Instrumentation.SqlClient
+* Use 1.10.0-beta.1 of OpenTelemetry.Instrumentation.StackExchangeRedis
+* Use 1.10.0-beta.1 of OpenTelemetry.Instrumentation.Wcf
+* Use 1.10.0-beta.1 of OpenTelemetry.Resources.Container
+* Use 1.10.0-beta.1 of OpenTelemetry.Resources.Host
+* Use 1.10.0-beta.1 of OpenTelemetry.Resources.OperatingSystem
+* Use 1.10.0-beta.1 of OpenTelemetry.Resources.Process
+* Use 1.10.0-beta.1 of OpenTelemetry.Resources.ProcessRuntime
 
 ## 1.0.1
 

--- a/examples/net8.0/aspnetcore/aspnetcore.csproj
+++ b/examples/net8.0/aspnetcore/aspnetcore.csproj
@@ -12,9 +12,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
+++ b/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
@@ -19,38 +19,38 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="MinVer" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OpenTelemetry" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
   </ItemGroup>
 
   <!-- Stable instrumentation packages -->
   <ItemGroup>
     <PackageReference Include="MySql.Data.OpenTelemetry" Version="8.2.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with no dependencies -->
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.9.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.6" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.9.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.10.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.10.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.10.0-beta.1" />
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with no dependencies, non netstandard2.0 -->
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <PackageReference Include="OpenTelemetry.Resources.Host" Version="0.1.0-beta.3" />
-    <PackageReference Include="OpenTelemetry.Resources.OperatingSystem" Version="0.1.0-alpha.4" />
-    <PackageReference Include="OpenTelemetry.Resources.Process" Version="0.1.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Resources.ProcessRuntime" Version="0.1.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Resources.Host" Version="1.10.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Resources.OperatingSystem" Version="1.10.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Resources.Process" Version="1.10.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Resources.ProcessRuntime" Version="1.10.0-beta.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -64,7 +64,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.0.0-beta.9" />
+    <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.10.0-beta.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
+++ b/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
@@ -38,35 +38,35 @@
        version of 3.16.0. We change this to 3.17.0, as the previous versions have dependency
        requirements that conflict with recent .NET package versions. -->
   <ItemGroup>
-    <PackageReference Include="CassandraCSharpDriver" Version="[3.17.0,)" />
+    <PackageReference Include="CassandraCSharpDriver" Version="3.22.0" />
   </ItemGroup>
 
   <!-- Stable instrumentation packages with dependencies, only .NET -->
   <ItemGroup Condition=" '$(TargetFramework)' != 'net462' ">
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" /> <!-- needed for AspNetCore -->
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" /> <!-- needed for AspNetCore -->
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with dependencies, both .NET framework and .NET -->
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.10.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Cassandra" Version="1.0.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.10.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Cassandra" Version="1.0.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.ElasticsearchClient" Version="1.0.0-beta.5" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.12" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.6.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.10.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.9.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.MySqlData" Version="1.0.0-beta.7" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.0.0-beta.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.9.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Wcf" Version="1.0.0-rc.17" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.10.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.10.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Wcf" Version="1.10.0-beta.1" />
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with dependencies, only .NET -->
   <ItemGroup Condition=" '$(TargetFramework)' != 'net462' ">
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.1" />
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with dependencies, only .NET framework -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.9.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.10.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Owin" Version="1.0.0-rc.6" />
   </ItemGroup>
 
@@ -81,7 +81,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.10.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.10.0-beta.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Changes

Upgrade to SDK 1.10.0, bump all dependencies.

## Merge requirement checklist

* [ ] Unit tests added/updated
* [ ] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
