### PR TITLE
Remove dependency on Mysql.Data.OpenTelemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,26 @@
 # Changelog
 
-## Unreleased
+## 1.1.0
 
 ### BREAKING CHANGES
 
+* Drop dependency on MySQL.Data.OpenTelemetry
+  ([#131](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/131))
 * Drop support for .NET 6. EOL was November 12 2024
+  ([#131](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/131))
 
 ### New features
 
+* Use 8.0.1 of Microsoft.Extensions.Logging
+  ([#128](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/128))
 * Use 1.10.0-beta.1 of OpenTelemetry.Instrumentation.AWS
+  ([#127](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/127))
 * Use 1.10.0-beta.1 of OpenTelemetry.Instrumentation.AWSLambda
+  ([#127](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/127))
+* Use 0.5.0-beta.7 of OpenTelemetry.Instrumentation.Process
+  ([#128](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/128))
+* Use 0.1.0-beta.3 of OpenTelemetry.Resources.Process
+  ([#128](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/128))
 
 ## 1.0.1
 

--- a/docs/supported-instrumentations.md
+++ b/docs/supported-instrumentations.md
@@ -37,4 +37,5 @@ and [minimal](./installation.md#install-the-base-package) dependencies:
 * The `ContainerResource` instrumentation is included but needs to be explicitly
   activated, as it currently adds container resource attributes for processes
   running not in containers.
-* The `MySqlData` instrumentation does not include the MySql.Data.OpenTelemetry package. Install separately if needed.
+* The `MySqlData` instrumentation does not include the MySql.Data.OpenTelemetry
+  package. Install separately if needed.

--- a/docs/supported-instrumentations.md
+++ b/docs/supported-instrumentations.md
@@ -20,13 +20,13 @@ and [minimal](./installation.md#install-the-base-package) dependencies:
 | `Hangfire`            | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.Hangfire](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Hangfire) |
 | `HttpClient`          | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Instrumentation.Http](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Http) |
 | `HostResource`        | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Resources.Host](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Resources.Host) |
+| `MySqlData`           | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Instrumentation.MySqlData](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.MySqlData) |
+|                       |                    |                    | [MySql.Data.OpenTelemetry](https://www.nuget.org/packages/MySql.Data.OpenTelemetry) |
 | `NetRuntime`          | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Instrumentation.Runtime](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Runtime) |
+| `Owin`                | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.Owin](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Owin) |
 | `Process`             | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Instrumentation.Process](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Process) |
 | `ProcessResource`     | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Resources.Process](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Resources.Process) |
 | `ProcessRuntimeResource`| :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Resources.ProcessRuntime](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Resources.ProcessRuntime) |
-| `MySqlData`           | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Instrumentation.MySqlData](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.MySqlData) |
-|                       | :heavy_check_mark: |                    | [MySql.Data.OpenTelemetry](https://www.nuget.org/packages/MySql.Data.OpenTelemetry) |
-| `Owin`                | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.Owin](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Owin) |
 | `Quartz`              | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.Quartz](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Quartz) |
 | `SqlClient`           | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Instrumentation.SqlClient](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.SqlClient) |
 | `StackExchangeRedis`  | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.StackExchangeRedis](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.StackExchangeRedis) |
@@ -37,3 +37,4 @@ and [minimal](./installation.md#install-the-base-package) dependencies:
 * The `ContainerResource` instrumentation is included but needs to be explicitly
   activated, as it currently adds container resource attributes for processes
   running not in containers.
+* The `MySqlData` instrumentation does not include the MySql.Data.OpenTelemetry package. Install separately if needed.

--- a/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
+++ b/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
@@ -33,7 +33,6 @@
 
   <!-- Stable instrumentation packages -->
   <ItemGroup>
-    <PackageReference Include="MySql.Data.OpenTelemetry" Version="8.4.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
   </ItemGroup>
 

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/MySqlDataInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/MySqlDataInitializer.cs
@@ -14,7 +14,11 @@ namespace Grafana.OpenTelemetry
         protected override void InitializeTracing(TracerProviderBuilder builder)
         {
             // MySQL.Data.OpenTelemetry
-            builder.AddConnectorNet();
+            ReflectionHelper.CallStaticMethod(
+                "MySQL.Data.OpenTelemetry",
+                "OpenTelemetry.Trace.TracerProviderBuilderExtensions",
+                "AddConnectorNet",
+                new object[] { builder });
 
             // OpenTelemetry.Instrumentation.MySqlData
             ReflectionHelper.CallStaticMethod(


### PR DESCRIPTION
Fixes #

## Changes

Remove dependency on Mysql.Data.OpenTelemetry

## Merge requirement checklist

* [ ] Unit tests added/updated
* [x] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
