### PR TITLE
Remove netstandard from tests

### DIFF
--- a/tests/Grafana.OpenTelemetry.Tests/Grafana.OpenTelemetry.Tests.csproj
+++ b/tests/Grafana.OpenTelemetry.Tests/Grafana.OpenTelemetry.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <Nullable>disable</Nullable>
 
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
## Changes

Avoid error running `dotnet test` by removing non-runnable TFM.

## Merge requirement checklist

* [ ] Unit tests added/updated
* [ ] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
