### PR TITLE
Use dotnet format from SDK

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,7 @@
 # All files
 [*]
 charset = utf-8
+end_of_line = crlf
 indent_style = space
 indent_size = 2
 insert_final_newline = true
@@ -106,7 +107,7 @@ csharp_style_prefer_index_operator = false:none
 csharp_style_prefer_range_operator = false:none
 csharp_style_pattern_local_over_anonymous_function = true:suggestion
 csharp_style_deconstructed_variable_declaration = true:suggestion
-csharp_style_namespace_declarations = file_scoped:warning
+csharp_style_namespace_declarations = file_scoped:suggestion
 
 # Space preferences
 csharp_space_after_cast = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -23,8 +23,5 @@ jobs:
       with:
         persist-credentials: false
 
-    - name: Install format tool
-      run: dotnet tool install -g dotnet-format
-
     - name: dotnet format
-      run: dotnet-format --folder --check
+      run: dotnet format --verify-no-changes

--- a/src/Grafana.OpenTelemetry.Base/ExporterSettings/OtlpExporter.cs
+++ b/src/Grafana.OpenTelemetry.Base/ExporterSettings/OtlpExporter.cs
@@ -4,7 +4,6 @@
 //
 
 using System;
-using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;

--- a/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryResourceDetector.cs
+++ b/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryResourceDetector.cs
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Reflection;
 using OpenTelemetry.Resources;
 

--- a/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetrySettings.cs
+++ b/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetrySettings.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Configuration;
 

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/OwinInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/OwinInitializer.cs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-using System;
 using OpenTelemetry.Trace;
 
 namespace Grafana.OpenTelemetry

--- a/src/Grafana.OpenTelemetry.Base/ReflectionHelper.cs
+++ b/src/Grafana.OpenTelemetry.Base/ReflectionHelper.cs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-using System;
 using System.Linq;
 using System.Reflection;
 

--- a/src/Grafana.OpenTelemetry.Base/ResourceDetectors/ContainerResource.cs
+++ b/src/Grafana.OpenTelemetry.Base/ResourceDetectors/ContainerResource.cs
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-using OpenTelemetry.Resources;
-
 #if NET8_0_OR_GREATER
+
+using OpenTelemetry.Resources;
 
 namespace Grafana.OpenTelemetry
 {

--- a/tests/Grafana.OpenTelemetry.Tests/GrafanaCloudConfigurationHelperTest.cs
+++ b/tests/Grafana.OpenTelemetry.Tests/GrafanaCloudConfigurationHelperTest.cs
@@ -4,7 +4,6 @@
 //
 
 using System;
-using Grafana.OpenTelemetry;
 using Xunit;
 
 namespace Grafana.OpenTelemetry.Tests

--- a/tests/Grafana.OpenTelemetry.Tests/GrafanaOpenTelemetrySettingsTest.cs
+++ b/tests/Grafana.OpenTelemetry.Tests/GrafanaOpenTelemetrySettingsTest.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using Grafana.OpenTelemetry;
 using Xunit;
 
 namespace Grafana.OpenTelemetry.Tests

--- a/tests/Grafana.OpenTelemetry.Tests/InMemoryResourceExporter.cs
+++ b/tests/Grafana.OpenTelemetry.Tests/InMemoryResourceExporter.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using OpenTelemetry;
-using OpenTelemetry.Exporter;
 using OpenTelemetry.Resources;
 
 namespace Grafana.OpenTelemetry.Tests

--- a/tests/Grafana.OpenTelemetry.Tests/MeterProviderExtensionsTest.cs
+++ b/tests/Grafana.OpenTelemetry.Tests/MeterProviderExtensionsTest.cs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-using Grafana.OpenTelemetry;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using Xunit;

--- a/tests/Grafana.OpenTelemetry.Tests/OpenTelemetryLoggerOptionsExtensionsTest.cs
+++ b/tests/Grafana.OpenTelemetry.Tests/OpenTelemetryLoggerOptionsExtensionsTest.cs
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-using Grafana.OpenTelemetry;
 using Microsoft.Extensions.Logging;
-using OpenTelemetry.Logs;
 using Xunit;
 
 namespace Grafana.OpenTelemetry.Tests

--- a/tests/Grafana.OpenTelemetry.Tests/ReflectionHelperTest.cs
+++ b/tests/Grafana.OpenTelemetry.Tests/ReflectionHelperTest.cs
@@ -4,7 +4,6 @@
 //
 
 using System;
-using Grafana.OpenTelemetry;
 using Xunit;
 
 namespace Grafana.OpenTelemetry.Tests

--- a/tests/Grafana.OpenTelemetry.Tests/TracerProviderExtensionsTest.cs
+++ b/tests/Grafana.OpenTelemetry.Tests/TracerProviderExtensionsTest.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using Grafana.OpenTelemetry;
 using OpenTelemetry;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;


### PR DESCRIPTION
## Changes

- Use `dotnet format` from the .NET SDK instead of the `dotnet-format` tool which is deprecated (see https://github.com/dotnet/format/issues/1268) and does not understand modern C# features like primary constructors.
- Fix warnings from `dotnet format`.
- Explicitly set the line endings to use for files.
- Downgrade `csharp_style_namespace_declarations` to a suggestion to avoid forcing adoption on existing files now and creating additional code churn.

## Merge requirement checklist

* [ ] Unit tests added/updated
* [ ] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
