### PR TITLE
Update OpenTelemetry package versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased version
 
+### BREAKING CHANGES
+
+* Update OpenTelemetry package versions to 1.12.0
+  ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+
+### New features
+
+* Enable metrics for SQL Client instrumentation
+  ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+* Use 1.0.0-beta.2 of OpenTelemetry.Instrumentation.Cassandra
+  ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+
 ### Bug Fixes
 
 * Remove reference on System.Text.Json for `net8.0` target framework

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@
 * Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.Hangfire ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
   * `ActivitySource.Version` is set to NuGet package version. ([#1624](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1624))
   * Added direct reference to `Newtonsoft.Json` with minimum version of `13.0.1`
-    [CVE-2024-21907](https://github.com/advisories/GHSA-5crp-9r3c-p9vr).
+    for [CVE-2024-21907](https://github.com/advisories/GHSA-5crp-9r3c-p9vr).
     ([#2058](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2058))
 * Use 1.12.0 of OpenTelemetry.Instrumentation.Http ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
   * Trace instrumentation no longer sets attributes when running on .NET 9 and
@@ -158,7 +158,7 @@
     Previously, it was written as a string. ([#2233](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2233))
   * The `EnableConnectionLevelAttributes` option is now enabled by default. ([#2249](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2249))
   * The following attributes are now provided when starting an activity for a
-  * database call: `db.system`, `db.name` (old conventions), `db.namespace` (new
+    database call: `db.system`, `db.name` (old conventions), `db.namespace` (new
     conventions), `server.address`, and `server.port`. These attributes are now
     available for sampling decisions. ([#2277](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2277))
   * The `SetDbStatementForStoredProcedure` option has been removed. ([#2284](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2284))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,55 +4,59 @@
 
 ### BREAKING CHANGES
 
-* Use 1.12.0 of OpenTelemetry ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
-  * Promoted the MetricPoint reclaim feature for Delta aggregation temporality
-    from experimental to stable. ([#5956](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5956))
-  * `Meter.Tags` will now be considered when resolving the SDK metric to update
-    when measurements are recorded. Meters with the same name and different tags
-    will now lead to unique metrics. ([#5982](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5982))
-  * Fixed a bug in tracing where `TraceState` set by a custom `Sampler` is not
-    applied when creating propagation-only spans. ([#6058](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6058))
+* Remove dependency on `OpenTelemetry.Instrumentation.MySqlData`.
+  Add the [MySql.Data.OpenTelemetry](https://www.nuget.org/packages/MySql.Data.OpenTelemetry)
+  package to your project if you require MySQL instrumentation. **NOTE**: This
+  NuGet package is licensed under the GPL license which may not be suitable for
+  all projects.
 * Use 1.12.0 of OpenTelemetry.Exporter.OpenTelemetryProtocol ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
-  * Non-primitive attribute (logs) and tag (traces) values converted using
-  * `Convert.ToString` will now format using `CultureInfo.InvariantCulture`. ([#5700](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5700))
-  * Fixed an issue causing `NotSupportedException`s to be thrown on startup when
-    `AddOtlpExporter` registration extensions are called while using custom dependency
-    injection containers which automatically create services (Unity, Grace, etc.).
-    ([#5808](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5808))
-  * Fixed `PlatformNotSupportedExceptions` being thrown during export when running
-  * on mobile platforms which caused telemetry to be dropped silently.
-    ([#5821](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5821))
-  * Added support for exporting instrumentation scope attributes from `ActivitySource.Tags`.
-    ([#5897](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5897))
-  * Removed dependency on `Google.Protobuf`, `Grpc` and `Grpc.Net.Client` packages.
-    ([#6005](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6005))
-  * Switched from using the `Google.Protobuf` library for serialization to a custom
-    manual implementation of protobuf serialization. ([#6005](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6005))
-  * Fixed an issue where a service.name was added to the resource if it was missing.
-    The exporter now respects the resource data provided by the SDK without
-    modifications. ([#6015](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6015))
-  * Removed the peer service resolver, which was based on earlier experimental
-    semantic conventions that are not part of the stable specification. ([#6005](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6005))
-  * Fixed incorrect log serialization of attributes with null values, causing
-    some backends to reject logs. ([#6149](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6149))
-  * Fixed an issue causing trace exports to fail when Activity.StatusDescription
-    exceeds 127 bytes. ([#6119](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6119))
-  * Fixed a bug in .NET Framework gRPC export client where the default success export
-    response was incorrectly marked as false, now changed to true, ensuring exports
-    are correctly marked as successful. ([#6099](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6099))`
   * Now defaults to exporting over OTLP/HTTP instead of OTLP/gRPC. This change
     could result in a failure to export telemetry unless appropriate measures
     are taken. Additionally, if you explicitly configure the exporter to use OTLP/gRPC
     it may result in a `NotSupportedException` without further configuration.
     Please review issue ([#6209](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6209))
     for additional information and workarounds. ([#6229](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6229))
+  * Removed the peer service resolver, which was based on earlier experimental
+    semantic conventions that are not part of the stable specification. ([#6005](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6005))
+* Use 1.12.0 of OpenTelemetry.Instrumentation.AWS ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Change default Semantic Convention to 1.28.
+  * Update AWSSDK dependencies to v4. ([#2720](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2720))
+* Use 1.12.0-beta.2 of OpenTelemetry.Instrumentation.SqlClient ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * The `peer.service` and `server.socket.address` attributes are no longer emitted.
+    Users should rely on the `server.address` attribute for the same information.
+    Note that server.address is only included when the `EnableConnectionLevelAttributes`
+    option is enabled. ([#2229](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2229))
+  * When `EnableConnectionLevelAttributes` is enabled, the `server.port` attribute
+    will now be written as an integer to be compliant with the semantic conventions.
+    Previously, it was written as a string. ([#2233](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2233))
+  * The `EnableConnectionLevelAttributes` option is now enabled by default. ([#2249](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2249))
+  * The `SetDbStatementForStoredProcedure` option has been removed. ([#2284](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2284))
+  * The `EnableConnectionLevelAttributes` option has been removed. ([#2414](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2414))
+  * Enabling `SetDbStatementForText` will no longer capture the raw query text.
+    The query is now sanitized. Literal values in the query text are replaced by
+    a `?` character. ([#2446](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2446))
+
+### New features
+
+* Enable metrics for SQL Client instrumentation
+  ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+* Use 1.12.0 of OpenTelemetry ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Promoted the MetricPoint reclaim feature for Delta aggregation temporality
+    from experimental to stable. ([#5956](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5956))
+  * `Meter.Tags` will now be considered when resolving the SDK metric to update
+    when measurements are recorded. Meters with the same name and different tags
+    will now lead to unique metrics. ([#5982](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5982))
+* Use 1.12.0 of OpenTelemetry.Exporter.OpenTelemetryProtocol ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Added support for exporting instrumentation scope attributes from `ActivitySource.Tags`.
+    ([#5897](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5897))
+  * Removed dependency on `Google.Protobuf`, `Grpc` and `Grpc.Net.Client` packages.
+    ([#6005](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6005))
+  * Switched from using the `Google.Protobuf` library for serialization to a custom
+    manual implementation of protobuf serialization. ([#6005](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6005))
 * Use 1.12.0 of OpenTelemetry.Extensions.Hosting ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
 * Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.AspNet ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
   * Updated registration extension code to retrieve environment variables through
     `IConfiguration`. ([#1976](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1976))
-  * Fixed an issue in ASP.NET instrumentation where route extraction failed for
-    attribute-based routing with multiple HTTP methods sharing the same route template.
-    ([#2250](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2250))
   * The `http.server.request.duration` histogram (measured in seconds) produced
     by the metrics instrumentation in this package now uses the Advice API to set
     default explicit buckets following the OpenTelemetry Specification. ([#2430](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2430))
@@ -64,44 +68,28 @@
     with the AspNetCoreTraceInstrumentationOptions.EnableAspNetCoreSignalRSupport
     option which defaults to true. Only applies to .NET 9.0 or greater. ([#2539](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2539))
 * Use 1.12.0 of OpenTelemetry.Instrumentation.AWS ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
-  * Trace instrumentation will now call the `Activity.SetStatus` API instead of
-    the deprecated OpenTelemetry API package extension when setting span status.
-    ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
   * Introduce `AWSClientInstrumentationOptions.SemanticConventionVersion` which
     provides a mechanism for developers to opt-in to newer versions of the of the
     OpenTelemetry Semantic Conventions. ([#2367](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2367))
-  * Change default Semantic Convention to 1.28.
   * Context propagation data is always added to SQS and SNS requests regardless of
     sampling decision. This enables downstream services to make consistent sampling
     decisions and prevents incomplete traces. ([#2447](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2447))
-  * Update AWSSDK dependencies to v4. ([#2720](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2720))
 * Use 1.12.0 of OpenTelemetry.Instrumentation.AWSLambda ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
-  * Trace instrumentation will now call the `Activity.SetStatus` API instead of
-    the deprecated OpenTelemetry API package extension when setting span status.
-    ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
   * Introduce `AWSClientInstrumentationOptions.SemanticConventionVersion` which
     provides a mechanism for developers to opt-in to newer versions of the of
     the Open Telemetry Semantic Conventions. ([#2367](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2367))
-  * Trace instrumentation will not fail with an exception if empty `LambdaContext`
-    instance is passed. ([#2457](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2457))
 * Use 1.0.0-beta.2 of OpenTelemetry.Instrumentation.Cassandra ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
   * `ActivitySource.Version` is set to NuGet package version. ([#1624](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1624))
   * Added direct reference to `Newtonsoft.Json` with minimum version of `13.0.1`
     in response to [CVE-2024-21907](https://github.com/advisories/GHSA-5crp-9r3c-p9vr).
     ([#2058](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2058))
 * Use 1.12.0-beta.2 of OpenTelemetry.Instrumentation.EntityFrameworkCore ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
-  * Trace instrumentation will now call the `Activity.SetStatus` API instead of
-    the deprecated OpenTelemetry API package extension when setting span status.
-    ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
   * The new database semantic conventions can be opted in to by setting the
     `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable. This allows for a
     transition period for users to experiment with the new semantic conventions
     and adapt as necessary. ([#2130](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2130))
   * Attribute `db.system` reports `oracle` when `Devart.Data.Oracle.Entity.EFCore`
     is used as a provider. ([#2465](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2465))
-  * Fixed attribute `db.system` for `Devart.Data.SQLite.Entity.EFCore`,
-    `Devart.Data.MySql.Entity.EFCore` and `Devart.Data.PostgreSql.Entity.EFCore`.
-    ([#2571](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2571))
   * Support use with SqlClient instrumentation.
     ([#2280](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2280),
     [#2829](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2829))
@@ -112,9 +100,6 @@
     for [CVE-2024-21907](https://github.com/advisories/GHSA-5crp-9r3c-p9vr).
     ([#2058](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2058))
 * Use 1.12.0 of OpenTelemetry.Instrumentation.Http ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
-  * Trace instrumentation no longer sets attributes when running on .NET 9 and
-    greater because HttpClient now includes native instrumentation which adds
-    attributes directly. ([#2314](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2314))
   * The `http.client.request.duration` histogram (measured in seconds) produced
     by the metrics instrumentation in this package now uses the Advice API to set
     default explicit buckets following the OpenTelemetry Specification. ([#2430](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2430))
@@ -124,19 +109,11 @@
     `IConfiguration`. ([#1973](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1973))
   * Updated to depend on the `OpenTelemetry.Api.ProviderBuilderExtensions` (API)
     package instead of the OpenTelemetry (SDK) package. ([#1977](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1977))
-  * Trace instrumentation will now call the `Activity.SetStatus` API instead of
-    the deprecated OpenTelemetry API package extension when setting span status.
-    ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
   * The `http.server.request.duration` histogram (measured in seconds) produced
     by the metrics instrumentation in this package now uses the Advice API to set
     default explicit buckets following the OpenTelemetry Specification. ([#2430](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2430))
-  * Fixed `url.query` value that was incorrectly always set to
-    `Microsoft.Owin.ReadableStringCollection`. ([#2732](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2732))
 * Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.Process ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
 * Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.Quartz ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
-  * Trace instrumentation will now call the `Activity.SetStatus` API instead of
-    the deprecated OpenTelemetry API package extension when setting span status.
-    ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
 * Use 1.12.0 of OpenTelemetry.Instrumentation.Runtime ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
   * Built-in .NET `System.Runtime` metrics are reported for .NET 9 and greater.
     For details about each individual metric check [.NET Runtime metrics docs page](https://learn.microsoft.com/dotnet/core/diagnostics/built-in-metrics-runtime).
@@ -149,34 +126,17 @@
     [#2277](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2277),
     [#2262](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2262),
     [#2279](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2279))
-  * The `peer.service` and `server.socket.address` attributes are no longer emitted.
-    Users should rely on the `server.address` attribute for the same information.
-    Note that server.address is only included when the `EnableConnectionLevelAttributes`
-    option is enabled. ([#2229](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2229))
-  * When `EnableConnectionLevelAttributes` is enabled, the `server.port` attribute
-    will now be written as an integer to be compliant with the semantic conventions.
-    Previously, it was written as a string. ([#2233](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2233))
-  * The `EnableConnectionLevelAttributes` option is now enabled by default. ([#2249](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2249))
   * The following attributes are now provided when starting an activity for a
     database call: `db.system`, `db.name` (old conventions), `db.namespace` (new
     conventions), `server.address`, and `server.port`. These attributes are now
     available for sampling decisions. ([#2277](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2277))
-  * The `SetDbStatementForStoredProcedure` option has been removed. ([#2284](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2284))
   * Add support for `metric db.client.operation.duration` from new database
     semantic conventions on .NET 8+. ([#2309](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2309))
   * Add support for metric `db.client.operation.duration` from new database
     semantic conventions on .NET Framework. ([#2311](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2311))
-  * The `EnableConnectionLevelAttributes` option has been removed. ([#2414](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2414))
   * The `db.client.operation.duration` histogram (measured in seconds) produced
     by the metrics instrumentation in this package now uses the Advice API to
     set default explicit buckets following the OpenTelemetry Specification. ([#2430](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2430))
-  * Enabling `SetDbStatementForText` will no longer capture the raw query text.
-    The query is now sanitized. Literal values in the query text are replaced by
-    a `?` character. ([#2446](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2446))
-  * Fix issue where IPv6 addresses were improperly parsed from the the connection's
-    `DataSource` when used to populate the `server.address` attribute. ([#2674](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2674))
-  * Fixes an issue that throws `IndexOutOfRangeException` in `SqlProcessor` when
-    the SQL statement ends with the beginning of a keyword such as `UPDATE`. ([#2674](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2674))
   * Add the `db.operation.name` attribute when `CommandType` is `StoredProcedure`
     to conform to the new semantic conventions. This affects you if you have
     opted into the new conventions. ([#2800](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2800))
@@ -187,18 +147,15 @@
     This will remain experimental while the specification remains in development.
     It is now only available on .NET 8 and newer. ([#2709](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2709))
 * Use 1.12.0-beta.2 of OpenTelemetry.Instrumentation.StackExchangeRedis ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
-  * Rename span network attributes to comply with v1.23.0 of Semantic Conventions
-    for Database Client Calls ([#2468](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2468))
   * `System.Reflection.Emit.Lightweight` is referenced only by `netstandard2.0`.
     ([#2667](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2667))
   * Add support for early filtering of telemetry collection via a `Filter` option
     ([#2804](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2804))
+  * Rename span network attributes to comply with v1.23.0 of Semantic Conventions
+    for Database Client Calls ([#2468](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2468))
 * Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.Wcf ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
   * Added a `RecordException` property to specify if exceptions should be recorded
     (defaults to `false`). This is only supported by client instrumentation. ([#2271](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2271))
-  * Trace instrumentation will now call the `Activity.SetStatus` API instead of
-    the deprecated OpenTelemetry API package extension when setting span status.
-    ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
   * Preserves `IsReadOnly` state of instrumented HTTP Headers. ([#2716](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2716))
 * Use 1.12.0-beta.1 of OpenTelemetry.Resources.Container ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
 * Use 1.12.0-beta.1 of OpenTelemetry.Resources.Host ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
@@ -206,23 +163,78 @@
 * Use 1.12.0-beta.1 of OpenTelemetry.Resources.Process ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
 * Use 1.12.0-beta.1 of OpenTelemetry.Resources.ProcessRuntime ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
 
-### New features
-
-* Enable metrics for SQL Client instrumentation
-  ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
-* Use 1.0.0-beta.2 of OpenTelemetry.Instrumentation.Cassandra
-  ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
-
 ### Bug Fixes
 
 * Remove reference on System.Text.Json for `net8.0` target framework
   ([#136](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/136))
-* Remove dependency on `OpenTelemetry.Instrumentation.MySqlData`.
-  Add the [MySql.Data.OpenTelemetry](https://www.nuget.org/packages/MySql.Data.OpenTelemetry)
-  package to your project if you require MySQL instrumentation. **NOTE**: This
-  NuGet package is licensed under the GPL license which may not be suitable for
-  all projects.
-  ([#146](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/146))
+([#146](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/146))
+* Use 1.12.0 of OpenTelemetry ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Fixed a bug in tracing where `TraceState` set by a custom `Sampler` is not
+    applied when creating propagation-only spans. ([#6058](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6058))
+* Use 1.12.0 of OpenTelemetry.Exporter.OpenTelemetryProtocol ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Non-primitive attribute (logs) and tag (traces) values converted using
+  * `Convert.ToString` will now format using `CultureInfo.InvariantCulture`. ([#5700](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5700))
+  * Fixed an issue causing `NotSupportedException`s to be thrown on startup when
+    `AddOtlpExporter` registration extensions are called while using custom dependency
+    injection containers which automatically create services (Unity, Grace, etc.).
+    ([#5808](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5808))
+  * Fixed `PlatformNotSupportedExceptions` being thrown during export when running
+  * on mobile platforms which caused telemetry to be dropped silently.
+    ([#5821](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5821))
+  * Fixed incorrect log serialization of attributes with null values, causing
+    some backends to reject logs. ([#6149](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6149))
+  * Fixed an issue causing trace exports to fail when Activity.StatusDescription
+    exceeds 127 bytes. ([#6119](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6119))
+  * Fixed a bug in .NET Framework gRPC export client where the default success export
+    response was incorrectly marked as false, now changed to true, ensuring exports
+    are correctly marked as successful. ([#6099](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6099))`
+* Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.AspNet ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Fixed an issue in ASP.NET instrumentation where route extraction failed for
+    attribute-based routing with multiple HTTP methods sharing the same route template.
+    ([#2250](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2250))
+  * The `http.server.request.duration` histogram (measured in seconds) produced
+    by the metrics instrumentation in this package now uses the Advice API to set
+    default explicit buckets following the OpenTelemetry Specification. ([#2430](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2430))
+* Use 1.12.0 of OpenTelemetry.Instrumentation.AWS ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Trace instrumentation will now call the `Activity.SetStatus` API instead of
+    the deprecated OpenTelemetry API package extension when setting span status.
+    ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
+* Use 1.12.0 of OpenTelemetry.Instrumentation.AWSLambda ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Trace instrumentation will now call the `Activity.SetStatus` API instead of
+    the deprecated OpenTelemetry API package extension when setting span status.
+    ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
+  * Trace instrumentation will not fail with an exception if empty `LambdaContext`
+    instance is passed. ([#2457](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2457))
+* Use 1.12.0-beta.2 of OpenTelemetry.Instrumentation.EntityFrameworkCore ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Trace instrumentation will now call the `Activity.SetStatus` API instead of
+    the deprecated OpenTelemetry API package extension when setting span status.
+    ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
+  * Fixed attribute `db.system` for `Devart.Data.SQLite.Entity.EFCore`,
+    `Devart.Data.MySql.Entity.EFCore` and `Devart.Data.PostgreSql.Entity.EFCore`.
+    ([#2571](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2571))
+* Use 1.12.0 of OpenTelemetry.Instrumentation.Http ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Trace instrumentation no longer sets attributes when running on .NET 9 and
+    greater because HttpClient now includes native instrumentation which adds
+    attributes directly. ([#2314](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2314))
+* Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.Owin ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Trace instrumentation will now call the `Activity.SetStatus` API instead of
+    the deprecated OpenTelemetry API package extension when setting span status.
+    ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
+  * Fixed `url.query` value that was incorrectly always set to
+    `Microsoft.Owin.ReadableStringCollection`. ([#2732](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2732))
+* Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.Quartz ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Trace instrumentation will now call the `Activity.SetStatus` API instead of
+    the deprecated OpenTelemetry API package extension when setting span status.
+    ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
+* Use 1.12.0-beta.2 of OpenTelemetry.Instrumentation.SqlClient ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Fix issue where IPv6 addresses were improperly parsed from the the connection's
+    `DataSource` when used to populate the `server.address` attribute. ([#2674](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2674))
+  * Fixes an issue that throws `IndexOutOfRangeException` in `SqlProcessor` when
+    the SQL statement ends with the beginning of a keyword such as `UPDATE`. ([#2674](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2674))
+* Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.Wcf ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Trace instrumentation will now call the `Activity.SetStatus` API instead of
+    the deprecated OpenTelemetry API package extension when setting span status.
+    ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
 * Use 1.0.0-rc.18 of OpenTelemetry.Instrumentation.Wcf
   ([#146](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/146))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,11 +186,13 @@
     environment variable to propagate trace context to SQL Server databases.
     This will remain experimental while the specification remains in development.
     It is now only available on .NET 8 and newer. ([#2709](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2709))
-* Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.StackExchangeRedis ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+* Use 1.12.0-beta.2 of OpenTelemetry.Instrumentation.StackExchangeRedis ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
   * Rename span network attributes to comply with v1.23.0 of Semantic Conventions
     for Database Client Calls ([#2468](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2468))
   * `System.Reflection.Emit.Lightweight` is referenced only by `netstandard2.0`.
     ([#2667](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2667))
+  * Add support for early filtering of telemetry collection via a `Filter` option
+    ([#2804](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2804))
 * Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.Wcf ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
   * Added a `RecordException` property to specify if exceptions should be recorded
     (defaults to `false`). This is only supported by client instrumentation. ([#2271](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2271))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,205 @@
 
 ### BREAKING CHANGES
 
-* Update OpenTelemetry package versions to 1.12.0
-  ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+* Use 1.12.0 of OpenTelemetry ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Promoted the MetricPoint reclaim feature for Delta aggregation temporality
+    from experimental to stable. ([#5956](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5956))
+  * `Meter.Tags` will now be considered when resolving the SDK metric to update
+    when measurements are recorded. Meters with the same name and different tags
+    will now lead to unique metrics. ([#5982](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5982))
+  * Fixed a bug in tracing where `TraceState` set by a custom `Sampler` is not
+    applied when creating propagation-only spans. ([#6058](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6058))
+* Use 1.12.0 of OpenTelemetry.Exporter.OpenTelemetryProtocol ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Non-primitive attribute (logs) and tag (traces) values converted using
+  * `Convert.ToString` will now format using `CultureInfo.InvariantCulture`. ([#5700](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5700))
+  * Fixed an issue causing `NotSupportedException`s to be thrown on startup when
+    `AddOtlpExporter` registration extensions are called while using custom dependency
+    injection containers which automatically create services (Unity, Grace, etc.).
+    ([#5808](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5808))
+  * Fixed `PlatformNotSupportedExceptions` being thrown during export when running
+  * on mobile platforms which caused telemetry to be dropped silently.
+    ([#5821](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5821))
+  * Added support for exporting instrumentation scope attributes from `ActivitySource.Tags`.
+    ([#5897](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5897))
+  * Removed dependency on `Google.Protobuf`, `Grpc` and `Grpc.Net.Client` packages.
+    ([#6005](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6005))
+  * Switched from using the `Google.Protobuf` library for serialization to a custom
+    manual implementation of protobuf serialization. ([#6005](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6005))
+  * Fixed an issue where a service.name was added to the resource if it was missing.
+    The exporter now respects the resource data provided by the SDK without
+    modifications. ([#6015](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6015))
+  * Removed the peer service resolver, which was based on earlier experimental
+    semantic conventions that are not part of the stable specification. ([#6005](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6005))
+  * Fixed incorrect log serialization of attributes with null values, causing
+    some backends to reject logs. ([#6149](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6149))
+  * Fixed an issue causing trace exports to fail when Activity.StatusDescription
+    exceeds 127 bytes. ([#6119](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6119))
+  * Fixed a bug in .NET Framework gRPC export client where the default success export
+    response was incorrectly marked as false, now changed to true, ensuring exports
+    are correctly marked as successful. ([#6099](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6099))`
+  * Now defaults to exporting over OTLP/HTTP instead of OTLP/gRPC. This change
+    could result in a failure to export telemetry unless appropriate measures
+    are taken. Additionally, if you explicitly configure the exporter to use OTLP/gRPC
+    it may result in a `NotSupportedException` without further configuration.
+    Please review issue ([#6209](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6209))
+    for additional information and workarounds. ([#6229](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6229))
+* Use 1.12.0 of OpenTelemetry.Extensions.Hosting ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+* Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.AspNet ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Updated registration extension code to retrieve environment variables through
+    `IConfiguration`. ([#1976](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1976))
+  * Fixed an issue in ASP.NET instrumentation where route extraction failed for
+    attribute-based routing with multiple HTTP methods sharing the same route template.
+    ([#2250](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2250))
+  * The `http.server.request.duration` histogram (measured in seconds) produced
+    by the metrics instrumentation in this package now uses the Advice API to set
+    default explicit buckets following the OpenTelemetry Specification. ([#2430](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2430))
+* Use 1.12.0 of OpenTelemetry.Instrumentation.AspNetCore ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * The `http.server.request.duration` histogram (measured in seconds) produced
+    by the metrics instrumentation in this package now uses the Advice API to set
+    default explicit buckets following the OpenTelemetry Specification. ([#2430](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2430))
+  * Added support for listening to ASP.NET Core SignalR activities. Configurable
+    with the AspNetCoreTraceInstrumentationOptions.EnableAspNetCoreSignalRSupport
+    option which defaults to true. Only applies to .NET 9.0 or greater. ([#2539](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2539))
+* Use 1.12.0 of OpenTelemetry.Instrumentation.AWS ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Trace instrumentation will now call the `Activity.SetStatus` API instead of
+    the deprecated OpenTelemetry API package extension when setting span status.
+    ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
+  * Introduce `AWSClientInstrumentationOptions.SemanticConventionVersion` which
+    provides a mechanism for developers to opt-in to newer versions of the of the
+    OpenTelemetry Semantic Conventions. ([#2367](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2367))
+  * Change default Semantic Convention to 1.28.
+  * Context propagation data is always added to SQS and SNS requests regardless of
+    sampling decision. This enables downstream services to make consistent sampling
+    decisions and prevents incomplete traces. ([#2447](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2447))
+  * Update AWSSDK dependencies to v4. ([#2720](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2720))
+* Use 1.12.0 of OpenTelemetry.Instrumentation.AWSLambda ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Trace instrumentation will now call the `Activity.SetStatus` API instead of
+    the deprecated OpenTelemetry API package extension when setting span status.
+    ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
+  * Introduce `AWSClientInstrumentationOptions.SemanticConventionVersion` which
+    provides a mechanism for developers to opt-in to newer versions of the of
+    the Open Telemetry Semantic Conventions. ([#2367](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2367))
+  * Trace instrumentation will not fail with an exception if empty `LambdaContext`
+    instance is passed. ([#2457](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2457))
+* Use 1.0.0-beta.2 of OpenTelemetry.Instrumentation.Cassandra ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * `ActivitySource.Version` is set to NuGet package version. ([#1624](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1624))
+  * Added direct reference to `Newtonsoft.Json` with minimum version of `13.0.1`
+    in response to [CVE-2024-21907](https://github.com/advisories/GHSA-5crp-9r3c-p9vr).
+    ([#2058](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2058))
+* Use 1.12.0-beta.2 of OpenTelemetry.Instrumentation.EntityFrameworkCore ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Trace instrumentation will now call the `Activity.SetStatus` API instead of
+    the deprecated OpenTelemetry API package extension when setting span status.
+    ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
+  * The new database semantic conventions can be opted in to by setting the
+    `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable. This allows for a
+    transition period for users to experiment with the new semantic conventions
+    and adapt as necessary. ([#2130](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2130))
+  * Attribute `db.system` reports `oracle` when `Devart.Data.Oracle.Entity.EFCore`
+    is used as a provider. ([#2465](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2465))
+  * Fixed attribute `db.system` for `Devart.Data.SQLite.Entity.EFCore`,
+    `Devart.Data.MySql.Entity.EFCore` and `Devart.Data.PostgreSql.Entity.EFCore`.
+    ([#2571](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2571))
+  * Support use with SqlClient instrumentation.
+    ([#2280](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2280),
+    [#2829](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2829))
+* Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.GrpcNetClient ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+* Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.Hangfire ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * `ActivitySource.Version` is set to NuGet package version. ([#1624](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1624))
+  * Added direct reference to `Newtonsoft.Json` with minimum version of `13.0.1`
+    [CVE-2024-21907](https://github.com/advisories/GHSA-5crp-9r3c-p9vr).
+    ([#2058](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2058))
+* Use 1.12.0 of OpenTelemetry.Instrumentation.Http ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Trace instrumentation no longer sets attributes when running on .NET 9 and
+    greater because HttpClient now includes native instrumentation which adds
+    attributes directly. ([#2314](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2314))
+  * The `http.client.request.duration` histogram (measured in seconds) produced
+    by the metrics instrumentation in this package now uses the Advice API to set
+    default explicit buckets following the OpenTelemetry Specification. ([#2430](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2430))
+* Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.Owin ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Updated activity tags to use new semantic conventions attribute schema. ([#2028](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2028))
+  * Updated registration extension code to retrieve environment variables through
+    `IConfiguration`. ([#1973](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1973))
+  * Updated to depend on the `OpenTelemetry.Api.ProviderBuilderExtensions` (API)
+    package instead of the OpenTelemetry (SDK) package. ([#1977](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1977))
+  * Trace instrumentation will now call the `Activity.SetStatus` API instead of
+    the deprecated OpenTelemetry API package extension when setting span status.
+    ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
+  * The `http.server.request.duration` histogram (measured in seconds) produced
+    by the metrics instrumentation in this package now uses the Advice API to set
+    default explicit buckets following the OpenTelemetry Specification. ([#2430](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2430))
+  * Fixed `url.query` value that was incorrectly always set to
+    `Microsoft.Owin.ReadableStringCollection`. ([#2732](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2732))
+* Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.Process ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+* Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.Quartz ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Trace instrumentation will now call the `Activity.SetStatus` API instead of
+    the deprecated OpenTelemetry API package extension when setting span status.
+    ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
+* Use 1.12.0 of OpenTelemetry.Instrumentation.Runtime ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Built-in .NET `System.Runtime` metrics are reported for .NET 9 and greater.
+    For details about each individual metric check [.NET Runtime metrics docs page](https://learn.microsoft.com/dotnet/core/diagnostics/built-in-metrics-runtime).
+    ([#2339](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2339))
+* Use 1.12.0-beta.2 of OpenTelemetry.Instrumentation.SqlClient ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * The new database semantic conventions can be opted in to by setting the
+    `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable. This allows for a
+    transition period for users to experiment with the new semantic conventions
+    and adapt as necessary. ([#2229](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2229),
+    [#2277](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2277),
+    [#2262](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2262),
+    [#2279](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2279))
+  * The `peer.service` and `server.socket.address` attributes are no longer emitted.
+    Users should rely on the `server.address` attribute for the same information.
+    Note that server.address is only included when the `EnableConnectionLevelAttributes`
+    option is enabled. ([#2229](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2229))
+  * When `EnableConnectionLevelAttributes` is enabled, the `server.port` attribute
+    will now be written as an integer to be compliant with the semantic conventions.
+    Previously, it was written as a string. ([#2233](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2233))
+  * The `EnableConnectionLevelAttributes` option is now enabled by default. ([#2249](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2249))
+  * The following attributes are now provided when starting an activity for a
+  * database call: `db.system`, `db.name` (old conventions), `db.namespace` (new
+    conventions), `server.address`, and `server.port`. These attributes are now
+    available for sampling decisions. ([#2277](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2277))
+  * The `SetDbStatementForStoredProcedure` option has been removed. ([#2284](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2284))
+  * Add support for `metric db.client.operation.duration` from new database
+    semantic conventions on .NET 8+. ([#2309](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2309))
+  * Add support for metric `db.client.operation.duration` from new database
+    semantic conventions on .NET Framework. ([#2311](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2311))
+  * The `EnableConnectionLevelAttributes` option has been removed. ([#2414](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2414))
+  * The `db.client.operation.duration` histogram (measured in seconds) produced
+    by the metrics instrumentation in this package now uses the Advice API to
+    set default explicit buckets following the OpenTelemetry Specification. ([#2430](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2430))
+  * Enabling `SetDbStatementForText` will no longer capture the raw query text.
+    The query is now sanitized. Literal values in the query text are replaced by
+    a `?` character. ([#2446](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2446))
+  * Fix issue where IPv6 addresses were improperly parsed from the the connection's
+    `DataSource` when used to populate the `server.address` attribute. ([#2674](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2674))
+  * Fixes an issue that throws `IndexOutOfRangeException` in `SqlProcessor` when
+    the SQL statement ends with the beginning of a keyword such as `UPDATE`. ([#2674](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2674))
+  * Add the `db.operation.name` attribute when `CommandType` is `StoredProcedure`
+    to conform to the new semantic conventions. This affects you if you have
+    opted into the new conventions. ([#2800](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2800))
+  * Add the `db.query.summary` attribute. This affects you if you have opted into
+    the new conventions. ([#2811](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2811))
+  * Added `OTEL_DOTNET_EXPERIMENTAL_SQLCLIENT_ENABLE_TRACE_CONTEXT_PROPAGATION`
+    environment variable to propagate trace context to SQL Server databases.
+    This will remain experimental while the specification remains in development.
+    It is now only available on .NET 8 and newer. ([#2709](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2709))
+* Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.StackExchangeRedis ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Rename span network attributes to comply with v1.23.0 of Semantic Conventions
+    for Database Client Calls ([#2468](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2468))
+  * `System.Reflection.Emit.Lightweight` is referenced only by `netstandard2.0`.
+    ([#2667](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2667))
+* Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.Wcf ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+  * Added a `RecordException` property to specify if exceptions should be recorded
+    (defaults to `false`). This is only supported by client instrumentation. ([#2271](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2271))
+  * Trace instrumentation will now call the `Activity.SetStatus` API instead of
+    the deprecated OpenTelemetry API package extension when setting span status.
+    ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
+  * Preserves `IsReadOnly` state of instrumented HTTP Headers. ([#2716](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2716))
+* Use 1.12.0-beta.1 of OpenTelemetry.Resources.Container ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+* Use 1.12.0-beta.1 of OpenTelemetry.Resources.Host ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+* Use 1.12.0-beta.1 of OpenTelemetry.Resources.OperatingSystem ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+* Use 1.12.0-beta.1 of OpenTelemetry.Resources.Process ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
+* Use 1.12.0-beta.1 of OpenTelemetry.Resources.ProcessRuntime ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
 
 ### New features
 

--- a/docker/docker-compose-aspnetcore/oats.yaml
+++ b/docker/docker-compose-aspnetcore/oats.yaml
@@ -72,7 +72,8 @@ expected:
           attributes:
             db.statement: LPUSH
             db.system: redis
-            net.peer.name: redis
+            db.redis.database_index: '0'
+            server.address: redis
     - traceql: '{ span.http.route =~ "/api/todo/items/" }'
       spans:
         - name: 'main'

--- a/docker/docker-compose-aspnetcore/oats.yaml
+++ b/docker/docker-compose-aspnetcore/oats.yaml
@@ -80,6 +80,7 @@ expected:
     - traceql: '{ span.http.route =~ "/api/todo/items/" }'
       spans:
         - name: 'main'
+          allow-duplicates: true
           attributes:
             db.system: sqlite
             db.name: main

--- a/docker/docker-compose-aspnetcore/oats.yaml
+++ b/docker/docker-compose-aspnetcore/oats.yaml
@@ -80,7 +80,7 @@ expected:
           attributes:
             db.system: sqlite
             db.name: main
-            peer.service: /app/App_Data/TodoApp.db
+            server.address: /app/App_Data/TodoApp.db
             otel.library.name: OpenTelemetry.Instrumentation.EntityFrameworkCore
     - traceql: '{ span.http.route =~ "api/Aws/ListBuckets" }'
       spans:

--- a/docker/docker-compose-aspnetcore/oats.yaml
+++ b/docker/docker-compose-aspnetcore/oats.yaml
@@ -14,7 +14,7 @@ expected:
       contains:
         - 'Application started'
   metrics:
-    - promql: db.client.operation.duration{}
+    - promql: db_client_operation_duration{}
       value: '>= 0'
     - promql: http_client_request_duration_seconds_count{}
       value: '>= 0'

--- a/docker/docker-compose-aspnetcore/oats.yaml
+++ b/docker/docker-compose-aspnetcore/oats.yaml
@@ -14,9 +14,8 @@ expected:
       contains:
         - 'Application started'
   metrics:
-    # Investigate why this fails
-    #- promql: db_client_operation_duration{}
-    #  value: '>= 0'
+    - promql: db_client_operation_duration_seconds_count{}
+      value: '>= 0'
     - promql: http_client_request_duration_seconds_count{}
       value: '>= 0'
     - promql: http_client_request_duration_seconds_count{http_request_method="GET", http_response_status_code="200"}

--- a/docker/docker-compose-aspnetcore/oats.yaml
+++ b/docker/docker-compose-aspnetcore/oats.yaml
@@ -14,6 +14,8 @@ expected:
       contains:
         - 'Application started'
   metrics:
+    - promql: db.client.operation.duration{}
+      value: '>= 0'
     - promql: http_client_request_duration_seconds_count{}
       value: '>= 0'
     - promql: http_client_request_duration_seconds_count{http_request_method="GET", http_response_status_code="200"}

--- a/docker/docker-compose-aspnetcore/oats.yaml
+++ b/docker/docker-compose-aspnetcore/oats.yaml
@@ -14,8 +14,9 @@ expected:
       contains:
         - 'Application started'
   metrics:
-    - promql: db_client_operation_duration{}
-      value: '>= 0'
+    # Investigate why this fails
+    #- promql: db_client_operation_duration{}
+    #  value: '>= 0'
     - promql: http_client_request_duration_seconds_count{}
       value: '>= 0'
     - promql: http_client_request_duration_seconds_count{http_request_method="GET", http_response_status_code="200"}

--- a/examples/net8.0/aspnetcore/aspnetcore.csproj
+++ b/examples/net8.0/aspnetcore/aspnetcore.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.17" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
   </ItemGroup>

--- a/examples/net8.0/aspnetcore/aspnetcore.csproj
+++ b/examples/net8.0/aspnetcore/aspnetcore.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="4.0.3.1" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.6.2" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.17" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />

--- a/examples/net8.0/aspnetcore/aspnetcore.csproj
+++ b/examples/net8.0/aspnetcore/aspnetcore.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.418.2" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.3.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.17" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />

--- a/examples/net8.0/aspnetcore/aspnetcore.csproj
+++ b/examples/net8.0/aspnetcore/aspnetcore.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="4.0.6.2" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.17" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />

--- a/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
+++ b/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
@@ -25,7 +25,7 @@
   <ItemGroup Label="Non-stable instrumentation packages">
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.12.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.12.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.12.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Resources.Host" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Resources.OperatingSystem" Version="1.12.0-beta.1" />

--- a/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
+++ b/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
@@ -7,41 +7,39 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageReference Include="System.Text.Json" Version="8.0.6" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
     <PackageReference Include="MinVer" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OpenTelemetry" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
   </ItemGroup>
 
   <!-- Stable instrumentation packages -->
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with no dependencies -->
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.9.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.7" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.9.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.12.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.12.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.12.0-beta.1" />
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with no dependencies, non netstandard2.0 -->
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <PackageReference Include="OpenTelemetry.Resources.Host" Version="0.1.0-beta.3" />
-    <PackageReference Include="OpenTelemetry.Resources.OperatingSystem" Version="0.1.0-alpha.4" />
-    <PackageReference Include="OpenTelemetry.Resources.Process" Version="0.1.0-beta.3" />
-    <PackageReference Include="OpenTelemetry.Resources.ProcessRuntime" Version="0.1.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Resources.Host" Version="1.12.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Resources.OperatingSystem" Version="1.12.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Resources.Process" Version="1.12.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Resources.ProcessRuntime" Version="1.12.0-beta.1" />
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
-    <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.0.0-beta.9" />
+    <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.12.0-beta.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
+++ b/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
@@ -17,29 +17,20 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
   </ItemGroup>
 
-  <!-- Stable instrumentation packages -->
-  <ItemGroup>
+  <ItemGroup Label="Stable Instrumentation Packages">
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
   </ItemGroup>
 
-  <!-- Non-stable instrumentation packages with no dependencies -->
-  <ItemGroup>
+  <ItemGroup Label="Non-stable instrumentation packages">
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.12.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.12.0-beta.1" />
-  </ItemGroup>
-
-  <!-- Non-stable instrumentation packages with no dependencies, non netstandard2.0 -->
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+    <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Resources.Host" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Resources.OperatingSystem" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Resources.Process" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Resources.ProcessRuntime" Version="1.12.0-beta.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
-    <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.12.0-beta.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryEventSource.cs
+++ b/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryEventSource.cs
@@ -16,7 +16,7 @@ namespace Grafana.OpenTelemetry
     [EventSource(Name = "OpenTelemetry-Grafana-Distribution")]
     internal sealed partial class GrafanaOpenTelemetryEventSource : EventSource
     {
-        public static GrafanaOpenTelemetryEventSource Log = new GrafanaOpenTelemetryEventSource();
+        public static readonly GrafanaOpenTelemetryEventSource Log = new GrafanaOpenTelemetryEventSource();
 
         [NonEvent]
         public void EnabledMetricsInstrumentation(string instrumentationLibrary)

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/SqlClientInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/SqlClientInitializer.cs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
 namespace Grafana.OpenTelemetry
@@ -13,6 +14,11 @@ namespace Grafana.OpenTelemetry
     internal class SqlClientInitializer : InstrumentationInitializer
     {
         public override Instrumentation Id { get; } = Instrumentation.SqlClient;
+
+        protected override void InitializeMetrics(MeterProviderBuilder builder)
+        {
+            builder.AddSqlClientInstrumentation();
+        }
 
         protected override void InitializeTracing(TracerProviderBuilder builder)
         {

--- a/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
+++ b/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
@@ -26,39 +26,42 @@
        version of 3.16.0. We change this to 3.17.0, as the previous versions have dependency
        requirements that conflict with recent .NET package versions. -->
   <ItemGroup>
+    <!-- TODO Bump to 3.22.0? -->
     <PackageReference Include="CassandraCSharpDriver" Version="[3.17.0,)" />
   </ItemGroup>
 
   <!-- Stable instrumentation packages with dependencies, only .NET -->
   <ItemGroup Condition=" '$(TargetFramework)' != 'net462' ">
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" /> <!-- needed for AspNetCore -->
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" /> <!-- needed for AspNetCore -->
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with dependencies, both .NET framework and .NET -->
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.10.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Cassandra" Version="1.0.0-beta.1" />
+    <!-- TODO OpenTelemetry.Instrumentation.AWS@1.12.0 raises AWSSDK to v4 which is not compatible with v3 -->
+    <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.11.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Cassandra" Version="1.0.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.ElasticsearchClient" Version="1.0.0-beta.5" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.12" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.6.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.0.0-beta.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.9.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Wcf" Version="1.0.0-rc.18" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.9.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.MySqlData" Version="1.0.0-beta.7" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.12.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.12.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Wcf" Version="1.12.0-beta.1" />
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with dependencies, only .NET -->
   <ItemGroup Condition=" '$(TargetFramework)' != 'net462' ">
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with dependencies, only .NET framework -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.9.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Owin" Version="1.0.0-rc.6" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.12.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Owin" Version="1.12.0-beta.1" />
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
-    <PackageReference Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.10.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
+++ b/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
@@ -32,8 +32,9 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.12.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$([MSBuild]::GetTargetFrameworkIdentifier(`$(TargetFramework)`))' != '.NETFramework' ">
+  <ItemGroup Label="Non-stable instrumentation packages with dependencies, only .NET" Condition=" '$([MSBuild]::GetTargetFrameworkIdentifier(`$(TargetFramework)`))' != '.NETFramework' ">
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" /> <!-- Needed for ASP.NET Core -->
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
   </ItemGroup>
 
   <ItemGroup Label="Non-stable instrumentation packages with dependencies">
@@ -41,14 +42,9 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.ElasticsearchClient" Version="1.0.0-beta.5" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.12.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.MySqlData" Version="1.0.0-beta.7" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Wcf" Version="1.12.0-beta.1" />
-  </ItemGroup>
-
-  <ItemGroup Label="Non-stable instrumentation packages with dependencies, only .NET" Condition=" '$([MSBuild]::GetTargetFrameworkIdentifier(`$(TargetFramework)`))' != '.NETFramework' ">
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
   </ItemGroup>
 
   <ItemGroup Label="Non-stable instrumentation packages with dependencies, only .NET Framework" Condition=" '$([MSBuild]::GetTargetFrameworkIdentifier(`$(TargetFramework)`))' == '.NETFramework' ">

--- a/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
+++ b/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
@@ -37,8 +37,7 @@
 
   <!-- Non-stable instrumentation packages with dependencies, both .NET framework and .NET -->
   <ItemGroup>
-    <!-- TODO OpenTelemetry.Instrumentation.AWS@1.12.0 raises AWSSDK to v4 which is not compatible with v3 -->
-    <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.11.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Cassandra" Version="1.0.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.ElasticsearchClient" Version="1.0.0-beta.5" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.1" />

--- a/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
+++ b/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Cassandra" Version="1.0.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.ElasticsearchClient" Version="1.0.0-beta.5" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.9.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.MySqlData" Version="1.0.0-beta.7" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.12.0-beta.1" />

--- a/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
+++ b/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.12.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.12.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.12.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Wcf" Version="1.12.0-beta.1" />
   </ItemGroup>
 

--- a/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
+++ b/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
@@ -16,10 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj" />
-    <PackageReference Include="MinVer" Version="6.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- This dependency is pulled in by `OpenTelemetry.Instrumentation.Cassandra` with a minimum
@@ -30,14 +27,16 @@
     <PackageReference Include="CassandraCSharpDriver" Version="[3.17.0,)" />
   </ItemGroup>
 
-  <!-- Stable instrumentation packages with dependencies, only .NET -->
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net462' ">
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" /> <!-- needed for AspNetCore -->
+  <ItemGroup Label="Stable instrumentation packages with dependencies">
+    <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.12.0" />
   </ItemGroup>
 
-  <!-- Non-stable instrumentation packages with dependencies, both .NET framework and .NET -->
-  <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.12.0" />
+  <ItemGroup Condition=" '$([MSBuild]::GetTargetFrameworkIdentifier(`$(TargetFramework)`))' != '.NETFramework' ">
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" /> <!-- Needed for ASP.NET Core -->
+  </ItemGroup>
+
+  <ItemGroup Label="Non-stable instrumentation packages with dependencies">
     <PackageReference Include="OpenTelemetry.Instrumentation.Cassandra" Version="1.0.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.ElasticsearchClient" Version="1.0.0-beta.5" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.1" />
@@ -48,19 +47,13 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Wcf" Version="1.12.0-beta.1" />
   </ItemGroup>
 
-  <!-- Non-stable instrumentation packages with dependencies, only .NET -->
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net462' ">
+  <ItemGroup Label="Non-stable instrumentation packages with dependencies, only .NET" Condition=" '$([MSBuild]::GetTargetFrameworkIdentifier(`$(TargetFramework)`))' != '.NETFramework' ">
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
   </ItemGroup>
 
-  <!-- Non-stable instrumentation packages with dependencies, only .NET framework -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+  <ItemGroup Label="Non-stable instrumentation packages with dependencies, only .NET Framework" Condition=" '$([MSBuild]::GetTargetFrameworkIdentifier(`$(TargetFramework)`))' == '.NETFramework' ">
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Owin" Version="1.12.0-beta.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
-    <PackageReference Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
+++ b/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
@@ -39,7 +39,7 @@
   <ItemGroup Label="Non-stable instrumentation packages with dependencies">
     <PackageReference Include="OpenTelemetry.Instrumentation.Cassandra" Version="1.0.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.ElasticsearchClient" Version="1.0.0-beta.5" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.9.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.MySqlData" Version="1.0.0-beta.7" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.12.0-beta.1" />


### PR DESCRIPTION
## Changes

Update OpenTelemetry (and test) NuGet packages to their latest versions.

- Resolves #173.
- Resolves https://github.com/grafana/grafana-opentelemetry-dotnet/security/dependabot/9.
- Resolves https://github.com/grafana/grafana-opentelemetry-dotnet/security/dependabot/10.
- Resolves https://github.com/grafana/grafana-opentelemetry-dotnet/security/code-scanning/26.

This raises a few questions:

1. .NET 9 `Microsoft.Extensions.*` dependencies are forced onto .NET 8 applications (https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/2361).
    - I'm sure I saw an issue somewhere regarding the LTS-supported-ness of these related to Aspire, so I need to dig that out and determine if we need to either accept that change (and force it on our users), or push back upstream on the 9.0 change and instead introduce multi-targeting based on the TFM.
    - https://github.com/dotnet/aspire/issues/6741 is what I was thinking of, which they resolved by doing multi-targeting with different package versions (which is what [dotnet/extensions](https://github.com/dotnet/extensions) also does)
    - That in turn points at https://github.com/open-telemetry/opentelemetry-dotnet/issues/5973
    - This suggests to me we should push to get the libraries to do the same (which if agreed, I can pick up and do) - I've added this to the SIG agenda for this week.
2. OpenTelemetry.Instrumentation.AWS 1.12.0 updates the AWSSDK dependency to v4. v4 is not compatible with any v3 packages, so use of 1.12.0 forces any application to update **all** their AWS packages to v4.
    - Either we stay on 1.11.0 to stay on v3, or move to 1.12.0 and note this requirement. Basically, we need to pick a side.

## Merge requirement checklist

* [x] Unit tests added/updated
* [ ] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
