### PR TITLE
Remove deprecated packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 * Remove reference on System.Text.Json for `net8.0` target framework
   ([#136](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/136))
+* Remove dependency on `OpenTelemetry.Instrumentation.MySqlData`.
+  Add the [MySql.Data.OpenTelemetry](https://www.nuget.org/packages/MySql.Data.OpenTelemetry)
+  package to your project if you require MySQL instrumentation. **NOTE**: This
+  NuGet package is licensed under the GPL license which may not be suitable for
+  all projects.
+  ([#146](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/146))
+* Use 1.0.0-rc.18 of OpenTelemetry.Instrumentation.Wcf
+  ([#146](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/146))
 
 ## 1.2.0
 

--- a/docs/supported-instrumentations.md
+++ b/docs/supported-instrumentations.md
@@ -20,8 +20,8 @@ and [minimal](./installation.md#install-the-base-package) dependencies:
 | `Hangfire`            | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.Hangfire](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Hangfire) |
 | `HttpClient`          | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Instrumentation.Http](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Http) |
 | `HostResource`        | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Resources.Host](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Resources.Host) |
-| `MySqlData`           | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Instrumentation.MySqlData](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.MySqlData) |
-|                       |                    |                    | [MySql.Data.OpenTelemetry](https://www.nuget.org/packages/MySql.Data.OpenTelemetry) |
+| `MySqlData`           |                    |                    | [MySql.Data.OpenTelemetry](https://www.nuget.org/packages/MySql.Data.OpenTelemetry) |
+|                       |                    |                    | [OpenTelemetry.Instrumentation.MySqlData](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.MySqlData) :warning: **Deprecated** |
 | `NetRuntime`          | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Instrumentation.Runtime](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Runtime) |
 | `Owin`                | :heavy_check_mark: |                    | [OpenTelemetry.Instrumentation.Owin](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Owin) |
 | `Process`             | :heavy_check_mark: | :heavy_check_mark: | [OpenTelemetry.Instrumentation.Process](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Process) |
@@ -37,5 +37,5 @@ and [minimal](./installation.md#install-the-base-package) dependencies:
 * The `ContainerResource` instrumentation is included but needs to be explicitly
   activated, as it currently adds container resource attributes for processes
   running not in containers.
-* The `MySqlData` instrumentation does not include the MySql.Data.OpenTelemetry
-  package. Install separately if needed.
+* The `MySqlData` instrumentation is automatically enabled if it is present in
+  the application, but requires `MySql.Data.OpenTelemetry` to be manually installed.

--- a/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
+++ b/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
@@ -41,10 +41,9 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.ElasticsearchClient" Version="1.0.0-beta.5" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.12" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.6.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.MySqlData" Version="1.0.0-beta.7" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.0.0-beta.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.9.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Wcf" Version="1.0.0-rc.17" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Wcf" Version="1.0.0-rc.18" />
   </ItemGroup>
 
   <!-- Non-stable instrumentation packages with dependencies, only .NET -->


### PR DESCRIPTION
Fixes #124

## Changes

- Remove deprecated `OpenTelemetry.Instrumentation.MySqlData` package.
- Update `OpenTelemetry.Instrumentation.Wcf` to `1.0.0-rc.18`.

## Merge requirement checklist

* [ ] Unit tests added/updated
* [x] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
