### PR TITLE
Update .NET SDK

### DIFF
--- a/examples/net8.0/aspnetcore/aspnetcore.csproj
+++ b/examples/net8.0/aspnetcore/aspnetcore.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.16" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.17" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "8.0.410",
+    "version": "8.0.411",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
## Changes

Update to the latest .NET 8 SDK version.

This might be why OATs has started to fail, as the Docker images would have been updated yesterday.

## Merge requirement checklist

* [ ] Unit tests added/updated
* [ ] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
