### PR TITLE
Fix Renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,7 +17,7 @@
       "customType": "regex",
       "description": "Update _VERSION variables in scripts",
       "managerFilePatterns": ["*.ps1", "*.sh"],
-      "matchStrings": ["# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))?(?: packageName=(?<packageName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\s.+?_version=(?<currentValue>.+?)\\s"],
+      "matchStrings": ["# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))?(?: packageName=(?<packageName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\s.+?_version=(?<currentValue>.+?)\\s"]
     }
   ],
   "labels": [


### PR DESCRIPTION
Fixes #167.

## Changes

Remove trailing `,`.

## Merge requirement checklist

* [ ] Unit tests added/updated
* [ ] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
