### PR TITLE
adjust ignorePaths to pick up .NET examples

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,11 @@
     ":ignoreUnstable",
     ":timezone(UTC)"
   ],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/__fixtures__/**"
+  ],
   "automerge": true,
   "commitBodyTable": true,
   "customManagers": [


### PR DESCRIPTION
## Changes

Modify renovate recommended `ignoredPaths` to allow updates in ./tests and ./examples. The NuGet matcher already examines ./tests, but it does not appear other matchers do.

Default `ignorePaths`: https://docs.renovatebot.com/presets-default/#ignoremodulesandtests

## Merge requirement checklist

* [ ] Unit tests added/updated
* [ ] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
