### PR TITLE
Test packages with oats

### DIFF
--- a/.github/workflows/oats.yml
+++ b/.github/workflows/oats.yml
@@ -14,8 +14,36 @@ on:
 permissions: {}
 
 jobs:
+
+  package:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        fetch-depth: 0
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+
+    - name: Build NuGet packages
+      run: dotnet build --configuration Release
+
+    - name: Publish NuGet packages
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: oats-packages
+        path: ./artifacts/package/release
+        if-no-files-found: error
+
   acceptance-tests:
     runs-on: ubuntu-latest
+    needs: package
     timeout-minutes: 20
 
     steps:
@@ -26,6 +54,12 @@ jobs:
           filter: 'tree:0'
           persist-credentials: false
           show-progress: false
+
+      - name: Download packages
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: oats-packages
+          path: ./.packages
 
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
@@ -39,6 +73,8 @@ jobs:
         run: go install "github.com/grafana/oats@${OATS_VERSION}"
 
       - name: Run acceptance tests
+        env:
+          BUILD_DISTRO_FROM_SOURCE: false
         run: oats --timeout=5m ./docker/docker-compose-aspnetcore
 
       - name: Upload log file

--- a/.github/workflows/oats.yml
+++ b/.github/workflows/oats.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
+          cache: false
           go-version: '1.24'
 
       - name: Install OATS

--- a/.gitignore
+++ b/.gitignore
@@ -472,3 +472,6 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# Local NuGet package source
+!.packages/*.s?nupkg

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="local" value=".packages" />
+    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="local">
+      <package pattern="Grafana.OpenTelemetry" />
+      <package pattern="Grafana.OpenTelemetry.Base" />
+    </packageSource>
+    <packageSource key="NuGet">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/docker/docker-compose-aspnetcore/.dockerignore
+++ b/docker/docker-compose-aspnetcore/.dockerignore
@@ -23,3 +23,4 @@
 **/values.dev.yaml
 LICENSE
 README.md
+!.packages/

--- a/docker/docker-compose-aspnetcore/docker-compose.oats.yml
+++ b/docker/docker-compose-aspnetcore/docker-compose.oats.yml
@@ -4,6 +4,8 @@ services:
     build:
       context: ../..
       dockerfile: examples/net8.0/aspnetcore/Dockerfile
+      args:
+        DOTNET_PUBLISH_ARGS: "/p:BuildDistroFromSource=${BUILD_DISTRO_FROM_SOURCE:-true}"
     environment:
       - AWS_ACCESS_KEY_ID=localstack
       - AWS_SECRET_ACCESS_KEY=localstack

--- a/docker/docker-compose-aspnetcore/docker-compose.self-contained.oats.yml
+++ b/docker/docker-compose-aspnetcore/docker-compose.self-contained.oats.yml
@@ -5,7 +5,7 @@ services:
       context: ../..
       dockerfile: examples/net8.0/aspnetcore/Dockerfile
       args:
-        DOTNET_PUBLISH_ARGS: "--self-contained true /p:PublishSingleFile=true"
+        DOTNET_PUBLISH_ARGS: "--self-contained true /p:PublishSingleFile=true /p:BuildDistroFromSource=${BUILD_DISTRO_FROM_SOURCE:-true}"
     entrypoint: ./aspnetcore
     environment:
       - AWS_ACCESS_KEY_ID=localstack

--- a/docker/docker-compose-aspnetcore/docker-compose.yml
+++ b/docker/docker-compose-aspnetcore/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build:
       context: ../..
       dockerfile: examples/net8.0/aspnetcore/Dockerfile
+      args:
+        DOTNET_PUBLISH_ARGS: "/p:BuildDistroFromSource=${BUILD_DISTRO_FROM_SOURCE:-true}"
     depends_on:
       - redis
       - mssql

--- a/examples/net8.0/aspnetcore/Controllers/AwsController.cs
+++ b/examples/net8.0/aspnetcore/Controllers/AwsController.cs
@@ -17,7 +17,7 @@ public class AwsController(IAmazonS3 client, ILogger<AwsController> logger) : Co
     {
         var response = await client.ListBucketsAsync();
 
-        var buckets = response.Buckets.Select(o => o.BucketName).ToArray();
+        var buckets = response.Buckets?.Select(o => o.BucketName).ToArray() ?? [];
 
         logger.LogInformation("Found {Count} buckets.", buckets.Length);
 

--- a/examples/net8.0/aspnetcore/aspnetcore.csproj
+++ b/examples/net8.0/aspnetcore/aspnetcore.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(BuildDistroFromSource)' != 'false' ">

--- a/examples/net8.0/aspnetcore/aspnetcore.csproj
+++ b/examples/net8.0/aspnetcore/aspnetcore.csproj
@@ -19,8 +19,12 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(BuildDistroFromSource)' != 'false' ">
     <ProjectReference Include="..\..\..\src\Grafana.OpenTelemetry\Grafana.OpenTelemetry.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(BuildDistroFromSource)' == 'false' ">
+    <PackageReference Include="Grafana.OpenTelemetry" Version="*-*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #63

## Changes

- Refactor the OATS tests to consume the built NuGet packages, rather than compiling the distribution from source.
- Avoid warning when installing OATS by disabling the Go cache.
- Bump Swashbuckle.AspNetCore to the latest release.
- Cherry-pick change from https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145 to avoid `ArgumentException` when using v4 of the AWS SDK.

## Merge requirement checklist

* [ ] ~~Unit tests added/updated~~
* [ ] ~~[`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
