### PR TITLE
Address some native AoT warnings

### DIFF
--- a/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryEventSource.cs
+++ b/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetryEventSource.cs
@@ -7,10 +7,14 @@ using System;
 using System.Diagnostics.Tracing;
 using System.Text.Json;
 
+#if NET
+using System.Text.Json.Serialization;
+#endif
+
 namespace Grafana.OpenTelemetry
 {
     [EventSource(Name = "OpenTelemetry-Grafana-Distribution")]
-    internal sealed class GrafanaOpenTelemetryEventSource : EventSource
+    internal sealed partial class GrafanaOpenTelemetryEventSource : EventSource
     {
         public static GrafanaOpenTelemetryEventSource Log = new GrafanaOpenTelemetryEventSource();
 
@@ -53,7 +57,11 @@ namespace Grafana.OpenTelemetry
         [NonEvent]
         public void InitializeDistribution(GrafanaOpenTelemetrySettings settings)
         {
+#if NET
+            var settingsJson = JsonSerializer.Serialize(settings, GrafanaJsonSerializerContext.Default.GrafanaOpenTelemetrySettings);
+#else
             var settingsJson = JsonSerializer.Serialize(settings);
+#endif
 
             InitializeDistribution(settingsJson);
         }
@@ -75,5 +83,11 @@ namespace Grafana.OpenTelemetry
         {
             this.WriteEvent(3, signal, instrumentationLibrary, ex);
         }
+
+#if NET
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        [JsonSerializable(typeof(GrafanaOpenTelemetrySettings))]
+        private sealed partial class GrafanaJsonSerializerContext : JsonSerializerContext;
+#endif
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetrySettings.cs
+++ b/src/Grafana.OpenTelemetry.Base/GrafanaOpenTelemetrySettings.cs
@@ -38,7 +38,12 @@ namespace Grafana.OpenTelemetry
         ///
         /// By default, all available instrumentations are activated.
         /// </summary>
-        public HashSet<Instrumentation> Instrumentations { get; } = new HashSet<Instrumentation>((Instrumentation[])Enum.GetValues(typeof(Instrumentation)));
+        public HashSet<Instrumentation> Instrumentations { get; } =
+#if NET
+            [.. Enum.GetValues<Instrumentation>()];
+#else
+            new HashSet<Instrumentation>((Instrumentation[])Enum.GetValues(typeof(Instrumentation)));
+#endif
 
         /// <summary>
         /// Gets the list of resource detectors to be activated.
@@ -114,10 +119,11 @@ namespace Grafana.OpenTelemetry
             Instrumentations.Remove(Instrumentation.AWSLambda);
 
             var disableInstrumentations = configuration[DisableInstrumentationsEnvVarName];
+            char[] separators = new char[] { ',', ':' };
 
             if (!string.IsNullOrEmpty(disableInstrumentations))
             {
-                foreach (var instrumentationStr in disableInstrumentations.Split(new char[] { ',', ':' }))
+                foreach (var instrumentationStr in disableInstrumentations.Split(separators))
                 {
                     if (Enum.TryParse<Instrumentation>(instrumentationStr, out var instrumentation))
                     {
@@ -132,7 +138,7 @@ namespace Grafana.OpenTelemetry
             {
                 ResourceDetectors.Clear();
 
-                foreach (var resourceDetectorStr in resourceDetectors.Split(new char[] { ',', ':' }))
+                foreach (var resourceDetectorStr in resourceDetectors.Split(separators))
                 {
                     if (Enum.TryParse<ResourceDetector>(resourceDetectorStr, out var resourceDetector))
                     {
@@ -145,7 +151,7 @@ namespace Grafana.OpenTelemetry
 
             if (!string.IsNullOrEmpty(disableResourceDetectors))
             {
-                foreach (var resourceDetectorStr in disableResourceDetectors.Split(new char[] { ',', ':' }))
+                foreach (var resourceDetectorStr in disableResourceDetectors.Split(separators))
                 {
                     if (Enum.TryParse<ResourceDetector>(resourceDetectorStr, out var resourceDetector))
                     {

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/InstrumentationInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/InstrumentationInitializer.cs
@@ -4,38 +4,22 @@
 //
 
 using System;
+using System.Collections.Generic;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
+
+#if NET
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+#endif
 
 namespace Grafana.OpenTelemetry
 {
     internal abstract class InstrumentationInitializer
     {
-        public static InstrumentationInitializer[] Initializers = new InstrumentationInitializer[]
-        {
-#if NETFRAMEWORK
-            new AspNetInitializer(),
-            new OwinInitializer(),
-#endif
-            new AspNetCoreInitializer(),
-            new AWSInitializer(),
-            new AWSLambdaInitializer(),
-            new CassandraInitializer(),
-            new ElasticsearchClientInitializer(),
-            new EntityFrameworkCoreInitializer(),
-            new GrpcNetClientInitializer(),
-            new HangfireInitializer(),
-            new HttpClientInitializer(),
-            new MySqlDataInitializer(),
-            new NetRuntimeMetricsInitializer(),
-            new ProcessMetricsInitializer(),
-            new QuartzInitializer(),
-            new SqlClientInitializer(),
-            new StackExchangeRedisInitializer(),
-            new WcfInitializer(),
-        };
+        public static InstrumentationInitializer[] Initializers = GetDefaults();
 
-        abstract public Instrumentation Id { get; }
+        public abstract Instrumentation Id { get; }
 
         public void Initialize(TracerProviderBuilder builder)
         {
@@ -70,5 +54,48 @@ namespace Grafana.OpenTelemetry
 
         protected virtual void InitializeMetrics(MeterProviderBuilder builder)
         { }
+
+#if NET
+        [UnconditionalSuppressMessage(
+            "Trimming",
+            "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code",
+            Justification = "Usage of is SqlClientInitializer guarded.")]
+#endif
+        private static InstrumentationInitializer[] GetDefaults()
+        {
+            var initializers = new List<InstrumentationInitializer>
+            {
+#if NETFRAMEWORK
+                new AspNetInitializer(),
+                new OwinInitializer(),
+#endif
+                new AspNetCoreInitializer(),
+                new AWSInitializer(),
+                new AWSLambdaInitializer(),
+                new CassandraInitializer(),
+                new ElasticsearchClientInitializer(),
+                new EntityFrameworkCoreInitializer(),
+                new GrpcNetClientInitializer(),
+                new HangfireInitializer(),
+                new HttpClientInitializer(),
+                new MySqlDataInitializer(),
+                new NetRuntimeMetricsInitializer(),
+                new ProcessMetricsInitializer(),
+                new QuartzInitializer(),
+                new StackExchangeRedisInitializer(),
+                new WcfInitializer(),
+            };
+
+#if NET
+            if (RuntimeFeature.IsDynamicCodeSupported)
+            {
+                initializers.Add(new SqlClientInitializer());
+            }
+#else
+            initializers.Add(new SqlClientInitializer());
+#endif
+
+            return initializers.ToArray();
+        }
     }
 }

--- a/src/Grafana.OpenTelemetry.Base/Instrumentations/SqlClientInitializer.cs
+++ b/src/Grafana.OpenTelemetry.Base/Instrumentations/SqlClientInitializer.cs
@@ -7,6 +7,9 @@ using OpenTelemetry.Trace;
 
 namespace Grafana.OpenTelemetry
 {
+#if NET
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Trimming is not yet supported with SqlClient instrumentation.")]
+#endif
     internal class SqlClientInitializer : InstrumentationInitializer
     {
         public override Instrumentation Id { get; } = Instrumentation.SqlClient;


### PR DESCRIPTION
Contributes to #97.

## Changes

Address some native AoT warnings with .NET 8.

The only remaining warning is from the usage of `ReflectionHelper.CallStaticMethod()`.

Need to update the documentation to state somewhere that SQL instrumentation is not enabled when using native AoT.

## Merge requirement checklist

* [ ] ~~Unit tests added/updated~~
* [ ] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) file updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
