### PR TITLE
Test OATS changes

### DIFF
--- a/.github/workflows/oats.yml
+++ b/.github/workflows/oats.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Install OATS
         env:
           # renovate: datasource=github-releases depName=oats packageName=grafana/oats
-          OATS_VERSION: v0.3.2
+          OATS_VERSION: main
         run: go install "github.com/grafana/oats@${OATS_VERSION}"
 
       - name: Run acceptance tests


### PR DESCRIPTION
Validate changes from https://github.com/grafana/oats/pull/134 before release.
