### PR TITLE
Fix managerFilePatterns

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,7 +21,7 @@
     {
       "customType": "regex",
       "description": "Update _VERSION variables in scripts",
-      "managerFilePatterns": ["*.ps1", "*.sh"],
+      "managerFilePatterns": ["/.*\\.ps1$/", "/.*\\.sh$/"],
       "matchStrings": ["# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))?(?: packageName=(?<packageName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\s.+?_version=(?<currentValue>.+?)\\s"]
     }
   ],


### PR DESCRIPTION
# Changes

Fix Renovate not including the scripts correctly to keep OATS up-to-date.

I noticed just now that they were missing from #159.

## Merge requirement checklist

* [ ] ~~Unit tests added/updated~~
* [ ] ~~[`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) updated~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
