### PR TITLE
Bump OpenTelemetry.Instrumentation.ElasticsearchClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 * Use 1.12.0 of OpenTelemetry.Instrumentation.AWS ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
   * Change default Semantic Convention to 1.28.
   * Update AWSSDK dependencies to v4. ([#2720](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2720))
+* Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.ElasticsearchClient ([#208](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/208))
+  * Replace `db.url` attribute with `url.full` to comply with semantic conventions.
+    Redact `username` and `password` part of `url.full`.
+    ([#1684](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1684))
 * Use 1.12.0-beta.2 of OpenTelemetry.Instrumentation.SqlClient ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
   * The `peer.service` and `server.socket.address` attributes are no longer emitted.
     Users should rely on the `server.address` attribute for the same information.
@@ -98,9 +102,6 @@
     ([#1538](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1538))
   * ActivitySource.Version is set to NuGet package version.
     ([#1624](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1624))
-  * Replace `db.url` attribute with `url.full` to comply with semantic conventions.
-    Redact `username` and `password` part of `url.full`.
-    ([#1684](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1684))
 * Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.GrpcNetClient ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
 * Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.Hangfire ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
   * `ActivitySource.Version` is set to NuGet package version. ([#1624](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1624))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,14 @@
   * Support use with SqlClient instrumentation.
     ([#2280](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2280),
     [#2829](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2829))
+* Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.ElasticsearchClient ([#208](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/208))
+  * Span status is set based on semantic convention for client spans.
+    ([#1538](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1538))
+  * ActivitySource.Version is set to NuGet package version.
+    ([#1624](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1624))
+  * Replace `db.url` attribute with `url.full` to comply with semantic conventions.
+    Redact `username` and `password` part of `url.full`.
+    ([#1684](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1684))
 * Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.GrpcNetClient ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
 * Use 1.12.0-beta.1 of OpenTelemetry.Instrumentation.Hangfire ([#145](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/145))
   * `ActivitySource.Version` is set to NuGet package version. ([#1624](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1624))

--- a/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
+++ b/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
@@ -39,7 +39,7 @@
 
   <ItemGroup Label="Non-stable instrumentation packages with dependencies">
     <PackageReference Include="OpenTelemetry.Instrumentation.Cassandra" Version="1.0.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.ElasticsearchClient" Version="1.0.0-beta.5" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.ElasticsearchClient" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.12.0-beta.1" />


### PR DESCRIPTION
# Changes

Bump OpenTelemetry.Instrumentation.ElasticsearchClient to the latest version.

## Merge requirement checklist

* [ ] ~~Unit tests added/updated~~
* [x] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) updated
* [ ] ~~Changes in public API reviewed (if applicable)~~
