### PR TITLE
Use tools manifest for dotnet-validate version

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-validate": {
+      "version": "0.0.1-preview.537",
+      "commands": [
+        "dotnet-validate"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
 
     outputs:
       dotnet-sdk-version: ${{ steps.setup-dotnet.outputs.dotnet-version }}
+      dotnet-validate-version: ${{ steps.get-dotnet-tools-versions.outputs.dotnet-validate-version }}
 
     permissions:
       attestations: write
@@ -89,6 +90,14 @@ jobs:
         path: ./artifacts/package/release
         if-no-files-found: error
 
+    - name: Get .NET tools versions
+      id: get-dotnet-tools-versions
+      shell: pwsh
+      run: |
+        $manifest = (Get-Content "./.config/dotnet-tools.json" | Out-String | ConvertFrom-Json)
+        $dotnetValidateVersion = $manifest.tools.'dotnet-validate'.version
+        "dotnet-validate-version=${dotnetValidateVersion}" >> ${env:GITHUB_OUTPUT}
+
   validate-packages:
     needs: build-test
     runs-on: ubuntu-latest
@@ -106,8 +115,10 @@ jobs:
 
     - name: Validate NuGet packages
       shell: pwsh
+      env:
+        DOTNET_VALIDATE_VERSION: ${{ needs.build-test.outputs.dotnet-validate-version }}
       run: |
-        dotnet tool install --global dotnet-validate --version 0.0.1-preview.304 --allow-roll-forward
+        dotnet tool install --global dotnet-validate --version ${env:DOTNET_VALIDATE_VERSION} --allow-roll-forward
         $packages = Get-ChildItem -Filter "*.nupkg" | ForEach-Object { $_.FullName }
         $invalidPackages = 0
         foreach ($package in $packages) {


### PR DESCRIPTION
# Changes

Use a .NET tools manifest to manage the version of dotnet-validate, which then can be updated by renovate.

Also bumps the version to `0.0.1-preview.537`.

## Merge requirement checklist

* [ ] ~~Unit tests added/updated~~
* [ ] ~~[`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) updated~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
