### PR TITLE
Use NuGet Trusted Publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
           user=nuget:user
 
     - name: NuGet log in
-      uses: NuGet/login@d883674c922ba7e5cc0370927b10a33b67d54677 # v1
+      uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1.1.0
       id: nuget-login
       with:
         user: ${{ fromJSON(steps.get-user.outputs.secrets).user }}


### PR DESCRIPTION
# Changes

Switch to using GitHub OIDC for pushing packages to NuGet.org with [Trusted Publishing](https://devblogs.microsoft.com/dotnet/enhanced-security-is-here-with-the-new-trust-publishing-on-nuget-org/).

Resolves #264.

## TODO

- [x] Wait for Trusted Publishing to be available for our NuGet packages
- [x] Create Trusted Publishing policy in NuGet.org
- [x] Add `nuget:user` secret to Vault

## Merge requirement checklist

* [ ] ~~Unit tests added/updated~~
* [ ] ~~[`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) updated~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
