### PR TITLE
Fix renovate not updating tests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,9 @@
     ":ignoreUnstable",
     ":timezone(UTC)"
   ],
+  "ignorePresets": [
+    ":ignoreModulesAndTests"
+  ],
   "ignorePaths": [
     "**/node_modules/**",
     "**/bower_components/**",


### PR DESCRIPTION
# Changes

Ignore the `:ignoreModulesAndTests` preset so tests get updated.

## Merge requirement checklist

* [ ] ~~Unit tests added/updated~~
* [ ] ~~[`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-dotnet) updated~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
