### PR TITLE
Support .NET 11

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,7 @@ used, for example `Grafana.OpenTelemetry 0.6.0-beta.1`:
 
 *
 
-The .NET runtime version (e.g. `net462`, `net48`, `net8.0` etc.).
+The .NET runtime version (e.g. `net462`, `net48`, `net10.0` etc.).
 You can find this information in your `*.csproj` file:
 
 *

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,10 @@ jobs:
         filter: 'tree:0'
         show-progress: false
 
-    - name: Setup .NET 8 SDK
+    - name: Setup additional .NET SDKs
       uses: actions/setup-dotnet@baa11fbfe1d6520db94683bd5c7a3818018e4309 # v5.1.0
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '10.0.x'
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@baa11fbfe1d6520db94683bd5c7a3818018e4309 # v5.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,12 @@ jobs:
         filter: 'tree:0'
         show-progress: false
 
+    - name: Get Git commit timestamp
+      id: get-commit-timestamp
+      shell: pwsh
+      run: |
+        "epoch=$(git log -1 --pretty=%ct)" >> ${env:GITHUB_OUTPUT}
+
     - name: Setup additional .NET SDKs
       uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
       with:
@@ -67,6 +73,8 @@ jobs:
 
     - name: Build
       run: dotnet build --configuration Release
+      env:
+        SOURCE_DATE_EPOCH: ${{ steps.get-commit-timestamp.outputs.epoch }}
 
     - name: Test
       run: dotnet test --configuration Release --logger:"GitHubActions;report-warnings=false"

--- a/examples/net10.0/aspnetcore/Dockerfile
+++ b/examples/net10.0/aspnetcore/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0.103@sha256:0a506ab0c8aa077361af42f82569d364ab1b8741e967955d883e3f23683d473a AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:11.0-preview@sha256:c5aa0a301759a1b07654450e10e3ec78c3d476d0537263ca1ab5850d9f302fca AS build
 ARG TARGETARCH
 ARG CONFIGURATION="Release"
 ARG DOTNET_PUBLISH_ARGS=""
@@ -11,7 +11,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
     dotnet publish "examples/net10.0/aspnetcore/aspnetcore.csproj" --arch "${TARGETARCH}" --configuration "${CONFIGURATION}" --output /app ${DOTNET_PUBLISH_ARGS}
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.3-noble-chiseled-extra@sha256:b7dcab0a2c26dd114943605fa6aaa43f07956ed9ffcfcf63cc55cb9af5481779 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:11.0-preview-resolute-chiseled-extra@sha256:f6734c0ed950db463ba1ad5a2be281347df01f46ff3969399222e13093399dec AS final
 WORKDIR /app
 EXPOSE 8080
 

--- a/examples/net10.0/aspnetcore/Dockerfile
+++ b/examples/net10.0/aspnetcore/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:11.0-preview@sha256:c5aa0a301759a1b07654450e10e3ec78c3d476d0537263ca1ab5850d9f302fca AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:11.0.100-preview.3@sha256:f57ec3eed4e19479b72b7933fb1926fbb06859349d183f9614b202fd00575d7a AS build
 ARG TARGETARCH
 ARG CONFIGURATION="Release"
 ARG DOTNET_PUBLISH_ARGS=""
@@ -11,7 +11,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
     dotnet publish "examples/net10.0/aspnetcore/aspnetcore.csproj" --arch "${TARGETARCH}" --configuration "${CONFIGURATION}" --output /app ${DOTNET_PUBLISH_ARGS}
 
-FROM mcr.microsoft.com/dotnet/aspnet:11.0-preview-resolute-chiseled-extra@sha256:f6734c0ed950db463ba1ad5a2be281347df01f46ff3969399222e13093399dec AS final
+FROM mcr.microsoft.com/dotnet/aspnet:11.0.0-preview.3-resolute-chiseled-extra@sha256:489238050692a30f6091314cdc04921a4e4cf5e0a87de522252d8a5d605e6f71 AS final
 WORKDIR /app
 EXPOSE 8080
 

--- a/examples/net10.0/aspnetcore/Dockerfile
+++ b/examples/net10.0/aspnetcore/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:11.0.100-preview.3@sha256:f57ec3eed4e19479b72b7933fb1926fbb06859349d183f9614b202fd00575d7a AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:11.0.100-preview.5@sha256:322b57a006b21737287a3680fa860562d9a9fe3373e1d670fc4d5b8ad519de44 AS build
 ARG TARGETARCH
 ARG CONFIGURATION="Release"
 ARG DOTNET_PUBLISH_ARGS=""
@@ -11,7 +11,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
     dotnet publish "examples/net10.0/aspnetcore/aspnetcore.csproj" --arch "${TARGETARCH}" --configuration "${CONFIGURATION}" --output /app ${DOTNET_PUBLISH_ARGS}
 
-FROM mcr.microsoft.com/dotnet/aspnet:11.0.0-preview.3-resolute-chiseled-extra@sha256:489238050692a30f6091314cdc04921a4e4cf5e0a87de522252d8a5d605e6f71 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:11.0.0-preview.5-resolute-chiseled-extra@sha256:19e498692fa6d3c6b8527892a3aef2d825ceacbfe3384539c0a0dd53af464e4c AS final
 WORKDIR /app
 EXPOSE 8080
 

--- a/examples/net10.0/aspnetcore/Dockerfile
+++ b/examples/net10.0/aspnetcore/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:11.0.100-preview.5@sha256:322b57a006b21737287a3680fa860562d9a9fe3373e1d670fc4d5b8ad519de44 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:11.0.100-preview.7@sha256:fd96d62893be03527912ce16b32e4331a64e6cf93393129f783a59b11e651790 AS build
 ARG TARGETARCH
 ARG CONFIGURATION="Release"
 ARG DOTNET_PUBLISH_ARGS=""
@@ -11,7 +11,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
     dotnet publish "examples/net10.0/aspnetcore/aspnetcore.csproj" --arch "${TARGETARCH}" --configuration "${CONFIGURATION}" --output /app ${DOTNET_PUBLISH_ARGS}
 
-FROM mcr.microsoft.com/dotnet/aspnet:11.0.0-preview.5-resolute-chiseled-extra@sha256:19e498692fa6d3c6b8527892a3aef2d825ceacbfe3384539c0a0dd53af464e4c AS final
+FROM mcr.microsoft.com/dotnet/aspnet:11.0.0-preview.7-resolute-chiseled-extra@sha256:9d9fb8ebca958c66623f9c841818bd32aac717fdbb9a0d119c80cec965ac01af AS final
 WORKDIR /app
 EXPOSE 8080
 

--- a/examples/net10.0/aspnetcore/aspnetcore.csproj
+++ b/examples/net10.0/aspnetcore/aspnetcore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="4.0.18.6" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="11.0.0-preview.1.26104.118" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.2" />

--- a/examples/net10.0/aspnetcore/aspnetcore.csproj
+++ b/examples/net10.0/aspnetcore/aspnetcore.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="4.0.24.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="11.0.0-preview.3.26207.106" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="11.0.0-preview.5.26302.115" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.16.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />

--- a/examples/net10.0/aspnetcore/aspnetcore.csproj
+++ b/examples/net10.0/aspnetcore/aspnetcore.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="4.0.23" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="11.0.0-preview.1.26104.118" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="11.0.0-preview.3.26207.106" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />

--- a/examples/net10.0/aspnetcore/aspnetcore.csproj
+++ b/examples/net10.0/aspnetcore/aspnetcore.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="4.0.102.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="11.0.0-preview.5.26302.115" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="11.0.0-preview.7.26381.103" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.17.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "10.0.103",
+    "version": "11.0.100-preview.1.26104.118",
     "allowPrerelease": false
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "11.0.100-preview.3.26207.106",
+    "version": "11.0.100-preview.5.26302.115",
     "allowPrerelease": false
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "11.0.100-preview.1.26104.118",
+    "version": "11.0.100-preview.3.26207.106",
     "allowPrerelease": false
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "11.0.100-preview.5.26302.115",
+    "version": "11.0.100-preview.7.26381.103",
     "allowPrerelease": false
   }
 }

--- a/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
+++ b/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
@@ -4,16 +4,20 @@
     <Description>Minimal Grafana distribution of OpenTelemetry .NET</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <TargetFrameworks>net10.0;net8.0;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net11.0;net10.0;netstandard2.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.6" Condition="'$([MSBuild]::GetTargetFrameworkIdentifier(`$(TargetFramework)`))' != '.NETCoreApp'" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
+    <PackageReference Include="System.Text.Json" Version="[10.0.0,)" Condition="'$([MSBuild]::GetTargetFrameworkIdentifier(`$(TargetFramework)`))' != '.NETCoreApp'" />
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
     <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[10.0.0,)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0'))">
+    <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[11.0.0-preview.1.26104.118,)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -47,7 +51,7 @@
     </AssemblyAttribute>
   </ItemGroup>
 
-  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 

--- a/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
+++ b/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0'))">
-    <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[11.0.0-preview.3.26207.106,)" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[11.0.0-preview.5.26302.115,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
+++ b/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0'))">
-    <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[11.0.0-preview.1.26104.118,)" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[11.0.0-preview.3.26207.106,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
+++ b/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0'))">
-    <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[11.0.0-preview.5.26302.115,)" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[11.0.0-preview.7.26381.103,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
+++ b/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
@@ -4,7 +4,7 @@
     <Description>Full Grafana distribution of OpenTelemetry .NET</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <TargetFrameworks>net10.0;net8.0;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net11.0;net10.0;netstandard2.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <!--
@@ -57,7 +57,7 @@
     </AssemblyAttribute>
   </ItemGroup>
 
-  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 

--- a/tests/Grafana.OpenTelemetry.Tests/Grafana.OpenTelemetry.Tests.csproj
+++ b/tests/Grafana.OpenTelemetry.Tests/Grafana.OpenTelemetry.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net11.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition="$([System.OperatingSystem]::IsWindows())">$(TargetFrameworks);net481</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>


### PR DESCRIPTION
_Long-lived branch to validate against .NET 11 until it reaches GA in November 2026_

# Changes

- Add support for .NET 11.
- Drop support for .NET 8.

## Merge requirement checklist

* [x] Unit tests added/updated
* [ ] [`CHANGELOG.md`][changelog] updated
* [ ] ~~Changes in public API reviewed (if applicable)~~

[changelog]: https://github.com/grafana/grafana-opentelemetry-dotnet
