### PR TITLE
Update OpenTelemetry to 1.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased version
 
+## 1.6.1
+
+### Bug Fixes
+
+* Use 1.15.2 of OpenTelemetry ([#513](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/513))
+  * Added Task-based worker support for `BatchExportProcessor` and
+    `PeriodicExportingMetricReader` to enable OpenTelemetry to work in
+    single-threaded WebAssembly environments such as Blazor and Uno Platform.
+    ([#6379](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6379))
+* Use 1.15.2 of OpenTelemetry.Exporter.OpenTelemetryProtocol ([#513](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/513))
+  * Limit how much of the response body is read when export fails and
+    error logging is enabled.
+    ([#7017](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7017))
+* Use 1.15.2 of OpenTelemetry.Extensions.Hosting ([#513](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/513))
+
 ## 1.6.0
 
 ### BREAKING CHANGES

--- a/examples/net10.0/aspnetcore/aspnetcore.csproj
+++ b/examples/net10.0/aspnetcore/aspnetcore.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="4.0.20.3" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.21" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
   </ItemGroup>
 

--- a/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
+++ b/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
@@ -21,8 +21,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OpenTelemetry" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
   </ItemGroup>
 
   <ItemGroup Label="Stable Instrumentation Packages">

--- a/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
+++ b/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Non-stable instrumentation packages with dependencies, only .NET" Condition=" '$([MSBuild]::GetTargetFrameworkIdentifier(`$(TargetFramework)`))' != '.NETFramework' ">
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.1" /> <!-- Needed for ASP.NET Core -->
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" /> <!-- Needed for ASP.NET Core -->
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
   </ItemGroup>
 

--- a/tests/Grafana.OpenTelemetry.Tests/Grafana.OpenTelemetry.Tests.csproj
+++ b/tests/Grafana.OpenTelemetry.Tests/Grafana.OpenTelemetry.Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="8.0.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>


### PR DESCRIPTION
# Changes

- Update OpenTelemetry dependencies for 1.15.2.
- Update test NuGet packages to their latest versions.

## Merge requirement checklist

* [ ] ~~Unit tests added/updated~~
* [x] [`CHANGELOG.md`][changelog] updated
* [ ] ~~Changes in public API reviewed (if applicable)~~

[changelog]: https://github.com/grafana/grafana-opentelemetry-dotnet
