### PR TITLE
Pin GitHub Actions runner labels

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,6 +23,17 @@
   "customManagers": [
     {
       "customType": "regex",
+      "description": ["Update GitHub runner labels in workflow fields and matrix values"],
+      "managerFilePatterns": [
+        "/(^|/)(workflow-templates|\\.(?:github|gitea|forgejo)/(?:workflows|actions))/.+\\.ya?ml$/",
+        "/(^|/)action\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate:\\s*datasource=(?<datasource>github-runners)(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*?(?:\\s+versioning=(?<versioning>[^\\s]+))?(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*\\s*\\r?\\n\\s*(?:-\\s*)?(?:[A-Za-z0-9_-]+:\\s*)?['\"]?(?<depName>[a-zA-Z]+)-(?<currentValue>[A-Za-z0-9._-]+)['\"]?"
+      ]
+    },
+    {
+      "customType": "regex",
       "description": "Update _VERSION variables in scripts",
       "managerFilePatterns": ["/.*\\.ps1$/", "/.*\\.sh$/"],
       "matchStrings": ["# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))?(?: packageName=(?<packageName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\s.+?_version=(?<currentValue>.+?)\\s"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,14 @@ jobs:
       matrix:
         include:
           - os-name: macos
-            runner: macos-latest
+            # renovate: datasource=github-runners depType=github-runner
+            runner: macos-26
           - os-name: linux
-            runner: ubuntu-latest
+            # renovate: datasource=github-runners depType=github-runner
+            runner: ubuntu-24.04
           - os-name: windows
-            runner: windows-latest
+            # renovate: datasource=github-runners depType=github-runner
+            runner: windows-2025
 
     steps:
 
@@ -108,7 +111,7 @@ jobs:
 
   validate-packages:
     needs: build-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
 
     - name: Download packages
@@ -158,7 +161,7 @@ jobs:
 
   publish-feedz-io:
     needs: [ build-test, validate-packages ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: |
       github.event.repository.fork == false &&
       (github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/'))
@@ -199,7 +202,7 @@ jobs:
 
   draft-release:
     needs: [ build-test, validate-packages ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: |
       github.event.repository.fork == false &&
       startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   analysis:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       actions: read
@@ -49,7 +49,7 @@ jobs:
   codeql:
     if: ${{ !cancelled() }}
     needs: [ analysis ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Report status

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,7 +7,7 @@ permissions: {}
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   check-format:
-    runs-on: windows-latest
+    runs-on: windows-24.04
     permissions: {}
 
     steps:

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   check-format:
-    runs-on: windows-24.04
+    runs-on: windows-2025
     permissions: {}
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read

--- a/.github/workflows/oats.yml
+++ b/.github/workflows/oats.yml
@@ -15,7 +15,7 @@ permissions: {}
 jobs:
 
   package:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
 
@@ -41,7 +41,7 @@ jobs:
         if-no-files-found: error
 
   acceptance-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: package
     timeout-minutes: 20
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -24,7 +24,7 @@ permissions: {}
 jobs:
   publish-nuget:
     if: github.event.repository.fork == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     defaults:
       run:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -18,7 +18,7 @@ permissions: {}
 
 jobs:
   release:
-    runs-on: [ ubuntu-latest ]
+    runs-on: ubuntu-24.04
 
     concurrency:
       group: ${{ github.workflow }}


### PR DESCRIPTION
# Changes

- Use specific labels for GitHub Actions runners instead of `latest.
- Add support for having renovate update the labels when used in matrices.

## Merge requirement checklist

* [ ] ~~Unit tests added/updated~~
* [ ] ~~[`CHANGELOG.md`][changelog] updated~~
* [ ] ~~Changes in public API reviewed (if applicable)~~

[changelog]: https://github.com/grafana/grafana-opentelemetry-dotnet
