### PR TITLE
Bump OpenTelemetry packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased version
 
+## 1.10.1
+
+### Bug Fixes
+
+* Use 1.16.0-beta.2 of OpenTelemetry.Instrumentation.Hangfire ([#TODO](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/TODO))
+  * Fixed `NullReferenceException` in the metrics filter when a job's definition
+    cannot be resolved.
+    ([#4713](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4713))
+* Use 1.16.0-beta.2 of OpenTelemetry.Resources.Host ([#TODO](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/TODO))
+  * Specify full path for `ioreg` command on macOS`.
+    ([#4760](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4760))
+
 ## 1.10.0
 
 ### BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@
 
 ### Bug Fixes
 
-* Use 1.16.0-beta.2 of OpenTelemetry.Instrumentation.Hangfire ([#TODO](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/TODO))
+* Use 1.16.0-beta.2 of OpenTelemetry.Instrumentation.Hangfire ([#614](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/614))
   * Fixed `NullReferenceException` in the metrics filter when a job's definition
     cannot be resolved.
     ([#4713](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4713))
-* Use 1.16.0-beta.2 of OpenTelemetry.Resources.Host ([#TODO](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/TODO))
-  * Specify full path for `ioreg` command on macOS`.
+* Use 1.16.0-beta.2 of OpenTelemetry.Resources.Host ([#614](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/614))
+  * Specify full path for `ioreg` command on macOS.
     ([#4760](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4760))
 
 ## 1.10.0

--- a/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
+++ b/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.16.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.16.0-rc.1" />
     <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.16.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Resources.Host" Version="1.16.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Resources.Host" Version="1.16.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Resources.OperatingSystem" Version="1.16.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Resources.Process" Version="1.16.0-rc.1" />
     <PackageReference Include="OpenTelemetry.Resources.ProcessRuntime" Version="1.16.0-beta.1" />

--- a/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
+++ b/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
@@ -44,7 +44,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Cassandra" Version="1.0.0-beta.7" />
     <PackageReference Include="OpenTelemetry.Instrumentation.ElasticsearchClient" Version="1.16.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.16.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.16.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.16.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.16.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.16.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Wcf" Version="1.16.0-beta.1" />


### PR DESCRIPTION
# Changes

Update OpenTelemetry packages to their latest patch releases for 1.10.1.

## Merge requirement checklist

* [ ] ~~Unit tests added/updated~~
* [x] [`CHANGELOG.md`][changelog] updated
* [ ] ~~Changes in public API reviewed (if applicable)~~

[changelog]: https://github.com/grafana/grafana-opentelemetry-dotnet
