### PR TITLE
Update OpenTelemetry to v1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,111 @@
 
 ## Unreleased version
 
+## 1.11.0
+
+### New features
+
+* Use 1.17.0 of OpenTelemetry ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+  * The library is now marked as trim and native AOT compatible.
+    ([#7441](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7441))
+  * Add support for a schema URL on `Resource` instances.
+    ([#7472](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7472))
+  * Add the `ExcludedTagKeys` property to `MetricStreamConfiguration` to support
+    excluding specific tag keys from metric streams.
+    ([#7373](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7373))
+  * Add a verbose `OpenTelemetry-Sdk` self-diagnostics event that is emitted when
+    an activity is dropped because its local (in-process) parent is not recorded.
+    ([#7427](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7427))
+  * Replace the vendored copy of `EnvironmentVariablesConfigurationProvider` with
+    a direct dependency on the `Microsoft.Extensions.Configuration.EnvironmentVariables`
+    package. As a result, this distribution no longer references that package
+    explicitly, as it is now provided transitively by OpenTelemetry.
+    ([#7146](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7146))
+* Use 1.17.0 of OpenTelemetry.Api ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+  * The library is now marked as trim and native AOT compatible.
+    ([#7441](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7441))
+* Use 1.17.0 of OpenTelemetry.Exporter.OpenTelemetryProtocol ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+  * The library is now marked as trim and native AOT compatible.
+    ([#7441](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7441))
+  * The `Resource` schema URL is now exported on the OTLP `ResourceSpans`,
+    `ResourceMetrics`, and `ResourceLogs` messages.
+    ([#7472](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7472))
+  * Cache pre-serialized metric metadata (`Name`, `Description`, and `Unit`) to
+    avoid re-encoding it on every OTLP metric export.
+    ([#7307](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7307))
+* Use 1.17.0 of OpenTelemetry.Extensions.Hosting ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+  * The library is now marked as trim and native AOT compatible.
+    ([#7441](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7441))
+* Use 1.17.0 of OpenTelemetry.Instrumentation.AspNet ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+* Use 1.17.0 of OpenTelemetry.Instrumentation.AspNetCore ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+* Use 1.17.0 of OpenTelemetry.Instrumentation.AWS ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+  * The `cloud.region` attribute is now emitted on AWS SDK client spans for all
+    `SemanticConventionVersion` values.
+    ([#4770](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4770))
+* Use 1.17.0 of OpenTelemetry.Instrumentation.AWSLambda ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+  * Add the schema URL to the resource detector.
+    ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
+* Use 1.0.0-beta.8 of OpenTelemetry.Instrumentation.Cassandra ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+* Use 1.17.0-beta.1 of OpenTelemetry.Instrumentation.ElasticsearchClient ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+* Use 1.17.0-beta.1 of OpenTelemetry.Instrumentation.EntityFrameworkCore ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+* Use 1.17.0-beta.1 of OpenTelemetry.Instrumentation.GrpcNetClient ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+* Use 1.17.0-beta.1 of OpenTelemetry.Instrumentation.Hangfire ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+* Use 1.17.0 of OpenTelemetry.Instrumentation.Http ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+* Use 1.17.0-beta.1 of OpenTelemetry.Instrumentation.Owin ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+* Use 1.17.0-rc.1 of OpenTelemetry.Instrumentation.Process ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+* Use 1.17.0-beta.1 of OpenTelemetry.Instrumentation.Quartz ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+* Use 1.17.0 of OpenTelemetry.Instrumentation.Runtime ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+* Use 1.17.0 of OpenTelemetry.Instrumentation.SqlClient ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+* Use 1.17.0-beta.1 of OpenTelemetry.Instrumentation.StackExchangeRedis ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+* Use 1.17.0-beta.1 of OpenTelemetry.Instrumentation.Wcf ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+* Use 1.17.0-beta.1 of OpenTelemetry.Resources.Container ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+  * Add the schema URL to the resource detector.
+    ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
+* Use 1.17.0-beta.1 of OpenTelemetry.Resources.Host ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+  * Add the schema URL to the resource detector.
+    ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
+* Use 1.17.0-beta.1 of OpenTelemetry.Resources.OperatingSystem ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+  * Add the schema URL to the resource detector.
+    ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
+* Use 1.17.0-rc.1 of OpenTelemetry.Resources.Process ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+  * Add the schema URL to the resource detector.
+    ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
+* Use 1.17.0-beta.1 of OpenTelemetry.Resources.ProcessRuntime ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+  * Add the schema URL to the resource detector.
+    ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
+
+### Bug Fixes
+
+* Use 1.17.0 of OpenTelemetry ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+  * Fixed a metric point reclaim data race on Arm CPU architectures.
+    ([#7401](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7401))
+  * Fixed a metric storage leak that occurred when meters and instruments were
+    repeatedly created and disposed.
+    ([#7466](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7466))
+* Use 1.17.0 of OpenTelemetry.Api ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+  * Fixed `TraceContextPropagator` to normalize empty `tracestate` header values
+    to `null` when extracting trace context.
+    ([#7407](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7407),
+    [#7433](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7433))
+  * Updated `tracestate` key validation to comply with the W3C Trace Context
+    Level 2 grammar.
+    ([#7469](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7469))
+* Use 1.17.0 of OpenTelemetry.Exporter.OpenTelemetryProtocol ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+  * Fixed `OtlpLogExporter` so `OtlpExporterOptions.ExportProcessorType` and
+    `OtlpExporterOptions.BatchExportProcessorOptions` are respected when
+    `LogRecordExportProcessorOptions` are not configured.
+    ([#7399](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7399))
+  * Fixed the OTLP exporter dropping retryable data instead of saving it to disk
+    when persistent storage retry is enabled and an export exceeds the configured
+    timeout.
+    ([#7447](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7447))
+  * Fixed the OTLP/HTTP exporter silently dropping data, and the OTLP/gRPC
+    exporter logging incorrectly, when an export timed out.
+    ([#7455](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7455))
+* Use 1.17.0-rc.1 of OpenTelemetry.Resources.Process ([#629](https://github.com/grafana/grafana-opentelemetry-dotnet/pull/629))
+  * Fixed `process.creation.time` not being emitted as UTC.
+    ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
+
 ## 1.10.1
 
 ### Bug Fixes

--- a/examples/net10.0/aspnetcore/aspnetcore.csproj
+++ b/examples/net10.0/aspnetcore/aspnetcore.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.17.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 

--- a/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
+++ b/src/Grafana.OpenTelemetry.Base/Grafana.OpenTelemetry.Base.csproj
@@ -8,12 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.6" Condition="'$([MSBuild]::GetTargetFrameworkIdentifier(`$(TargetFramework)`))' != '.NETCoreApp'" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
-    <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[10.0.0,)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -21,24 +16,24 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OpenTelemetry" Version="1.16.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
   </ItemGroup>
 
   <ItemGroup Label="Stable Instrumentation Packages">
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.16.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.17.0" />
   </ItemGroup>
 
   <ItemGroup Label="Non-stable instrumentation packages">
-    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.16.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.16.0-rc.1" />
-    <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.16.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Resources.Host" Version="1.16.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Resources.OperatingSystem" Version="1.16.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Resources.Process" Version="1.16.0-rc.1" />
-    <PackageReference Include="OpenTelemetry.Resources.ProcessRuntime" Version="1.16.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.17.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.17.0-rc.1" />
+    <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.17.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Resources.Host" Version="1.17.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Resources.OperatingSystem" Version="1.17.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Resources.Process" Version="1.17.0-rc.1" />
+    <PackageReference Include="OpenTelemetry.Resources.ProcessRuntime" Version="1.17.0-beta.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
+++ b/src/Grafana.OpenTelemetry/Grafana.OpenTelemetry.csproj
@@ -27,31 +27,31 @@
   </ItemGroup>
 
   <ItemGroup Label="Stable instrumentation packages with dependencies">
-    <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.16.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AWS" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.17.0" />
   </ItemGroup>
 
   <ItemGroup Label="Stable instrumentation packages with dependencies, only .NET Framework" Condition=" '$([MSBuild]::GetTargetFrameworkIdentifier(`$(TargetFramework)`))' == '.NETFramework' ">
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.17.0" />
   </ItemGroup>
 
   <ItemGroup Label="Non-stable instrumentation packages with dependencies, only .NET" Condition=" '$([MSBuild]::GetTargetFrameworkIdentifier(`$(TargetFramework)`))' != '.NETFramework' ">
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" /> <!-- Needed for ASP.NET Core -->
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" /> <!-- Needed for ASP.NET Core -->
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
   </ItemGroup>
 
   <ItemGroup Label="Non-stable instrumentation packages with dependencies">
-    <PackageReference Include="OpenTelemetry.Instrumentation.Cassandra" Version="1.0.0-beta.7" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.ElasticsearchClient" Version="1.16.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.16.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.16.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.16.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.16.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Wcf" Version="1.16.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Cassandra" Version="1.0.0-beta.8" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.ElasticsearchClient" Version="1.17.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.17.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.17.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.17.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.17.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Wcf" Version="1.17.0-beta.1" />
   </ItemGroup>
 
   <ItemGroup Label="Non-stable instrumentation packages with dependencies, only .NET Framework" Condition=" '$([MSBuild]::GetTargetFrameworkIdentifier(`$(TargetFramework)`))' == '.NETFramework' ">
-    <PackageReference Include="OpenTelemetry.Instrumentation.Owin" Version="1.16.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Owin" Version="1.17.0-beta.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Changes

Update all OpenTelemetry NuGet packages to their latest versions for v1.17.

## Merge requirement checklist

* [ ] ~~Unit tests added/updated~~
* [x] [`CHANGELOG.md`][changelog] updated
* [ ] ~~Changes in public API reviewed (if applicable)~~

[changelog]: https://github.com/grafana/grafana-opentelemetry-dotnet
