### PR TITLE
Replace localstack with floci for OATS tests

### DIFF
--- a/docker/docker-compose-aspnetcore/docker-compose.oats.yml
+++ b/docker/docker-compose-aspnetcore/docker-compose.oats.yml
@@ -7,10 +7,10 @@ services:
       args:
         DOTNET_PUBLISH_ARGS: "/p:BuildDistroFromSource=${BUILD_DISTRO_FROM_SOURCE:-true}"
     environment:
-      - AWS_ACCESS_KEY_ID=localstack
-      - AWS_SECRET_ACCESS_KEY=localstack
+      - AWS_ACCESS_KEY_ID=floci
+      - AWS_SECRET_ACCESS_KEY=floci
       - AWS_REGION=us-east-1
-      - AWS_ENDPOINT_URL_S3=http://localstack:4566
+      - AWS_ENDPOINT_URL_S3=http://floci:4566
       - OTEL_BLRP_SCHEDULE_DELAY=5000
       - OTEL_BSP_SCHEDULE_DELAY=5000
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://lgtm:4317
@@ -37,8 +37,8 @@ services:
     environment:
     - ACCEPT_EULA=Y
     - MSSQL_SA_PASSWORD=Password12345%%
-  localstack:
-    image: localstack/localstack:4.14.0@sha256:3ebc37595918b8accb852f8048fef2aff047d465167edd655528065b07bc364a
+  floci:
+    image: floci/floci:1.5.34@sha256:b3b3a70a294b8ba8095385b8571ea1e4d44d494950d98de5e812cd9de02f506b
     ports:
       - "4510-4559:4510-4559"
       - "4566:4566"

--- a/docker/docker-compose-aspnetcore/docker-compose.self-contained.oats.yml
+++ b/docker/docker-compose-aspnetcore/docker-compose.self-contained.oats.yml
@@ -8,10 +8,10 @@ services:
         DOTNET_PUBLISH_ARGS: "--self-contained true /p:PublishSingleFile=true /p:BuildDistroFromSource=${BUILD_DISTRO_FROM_SOURCE:-true}"
     entrypoint: ./aspnetcore
     environment:
-      - AWS_ACCESS_KEY_ID=localstack
-      - AWS_SECRET_ACCESS_KEY=localstack
+      - AWS_ACCESS_KEY_ID=floci
+      - AWS_SECRET_ACCESS_KEY=floci
       - AWS_REGION=us-east-1
-      - AWS_ENDPOINT_URL_S3=http://localstack:4566
+      - AWS_ENDPOINT_URL_S3=http://floci:4566
       - OTEL_BLRP_SCHEDULE_DELAY=5000
       - OTEL_BSP_SCHEDULE_DELAY=5000
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://lgtm:4317
@@ -38,8 +38,8 @@ services:
     environment:
     - ACCEPT_EULA=Y
     - MSSQL_SA_PASSWORD=Password12345%%
-  localstack:
-    image: localstack/localstack:4.14.0@sha256:3ebc37595918b8accb852f8048fef2aff047d465167edd655528065b07bc364a
+  floci:
+    image: floci/floci:1.5.34@sha256:b3b3a70a294b8ba8095385b8571ea1e4d44d494950d98de5e812cd9de02f506b
     ports:
       - "4510-4559:4510-4559"
       - "4566:4566"

--- a/docker/docker-compose-aspnetcore/docker-compose.yml
+++ b/docker/docker-compose-aspnetcore/docker-compose.yml
@@ -12,10 +12,10 @@ services:
     ports:
       - "8080:8080" # for OATs
     environment:
-      - AWS_ACCESS_KEY_ID=localstack
-      - AWS_SECRET_ACCESS_KEY=localstack
+      - AWS_ACCESS_KEY_ID=floci
+      - AWS_SECRET_ACCESS_KEY=floci
       - AWS_REGION=us-east-1
-      - AWS_ENDPOINT_URL_S3=http://localstack:4566
+      - AWS_ENDPOINT_URL_S3=http://floci:4566
       - OTEL_BLRP_SCHEDULE_DELAY=5000
       - OTEL_BSP_SCHEDULE_DELAY=5000
       - OTEL_METRIC_EXPORT_INTERVAL=5000
@@ -30,8 +30,8 @@ services:
     environment:
     - ACCEPT_EULA=Y
     - MSSQL_SA_PASSWORD=Password12345%%
-  localstack:
-    image: localstack/localstack:4.14.0@sha256:3ebc37595918b8accb852f8048fef2aff047d465167edd655528065b07bc364a
+  floci:
+    image: floci/floci:1.5.34@sha256:b3b3a70a294b8ba8095385b8571ea1e4d44d494950d98de5e812cd9de02f506b
     ports:
       - "4510-4559:4510-4559"
       - "4566:4566"


### PR DESCRIPTION
# Changes

Replace localstack for OATS tests with [floci](https://github.com/floci-io/floci) due to [licensing changes](https://blog.localstack.cloud/the-road-ahead-for-localstack/) that means we won't get any future updates otherwise.

## Merge requirement checklist

* [x] Unit tests added/updated
* [ ] ~~[`CHANGELOG.md`][changelog] updated~~
* [ ] ~~Changes in public API reviewed (if applicable)~~

[changelog]: https://github.com/grafana/grafana-opentelemetry-dotnet
