### PR TITLE
Add security reporting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,3 +122,4 @@ follow it: sentence-case headings, present-tense active voice, address the reade
 (never asterisks) for unordered lists, ordered lists that always start each item with `1.`, use full
 product names ("OpenTelemetry", not "OTel"), and never strip YAML front matter. Refer to that file
 before substantial documentation work.
+- Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.


### PR DESCRIPTION
## What changed

- Added guidance to the repository's agent instructions directing security issues to Grafana's security reporting page instead of the repository.

## Why

This makes the expected reporting channel explicit for coding agents working in the repository.

## Validation

- `git diff --check`
- Confirmed the commit changes only one agent instruction file with one added line.
