### PR TITLE
fix: correct shared workflow action tag comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
 
     - name: Get GitHub token
       id: get-token
-      uses: grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # create-github-app-token/v0.2.2
+      uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
       with:
         github_app: grafana-otel-bot
         permission_set: default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
 
     - name: Get GitHub token
       id: get-token
-      uses: grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # v0.2.2
+      uses: grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # create-github-app-token/v0.2.2
       with:
         github_app: grafana-otel-bot
         permission_set: default

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Get GitHub token
         id: get-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # v0.2.2
+        uses: grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # create-github-app-token/v0.2.2
         with:
           github_app: grafana-otel-bot
           permission_set: default

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Get GitHub token
         id: get-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # create-github-app-token/v0.2.2
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: grafana-otel-bot
           permission_set: default


### PR DESCRIPTION
## What changed

Correct both `create-github-app-token` SHA comments from `# v0.2.2` to `# create-github-app-token/v0.2.2`.

## Why

The bare version comment omits the shared-workflows monorepo component name, which prevents Renovate from identifying the correct tag namespace and can cause lookup failures. The pinned SHA was verified against `create-github-app-token/v0.2.2`.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/publish-release.yml`
- `git diff --check`

`dotnet format --verify-no-changes` could not run because this checkout requires SDK 10.0.302, while only 10.0.201 and 10.0.202 are installed locally.

Related to grafana/shared-workflows#2255
